### PR TITLE
feat: add prisma provider configuration types in ExpressoConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expressots/core",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Expressots - modern, fast, lightweight nodejs web framework (@core)",
   "author": "Richard Zampieri",
   "main": "./lib/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expressots/core",
-  "version": "1.5.2",
+  "version": "1.5.1",
   "description": "Expressots - modern, fast, lightweight nodejs web framework (@core)",
   "author": "Richard Zampieri",
   "main": "./lib/cjs/index.js",

--- a/packages/core/src/common/project-config.provider.ts
+++ b/packages/core/src/common/project-config.provider.ts
@@ -5,12 +5,22 @@ const enum Pattern {
   CAMEL_CASE = "camelCase",
 }
 
+interface IProviders {
+	prisma?: {
+		schemaName: string;
+		schemaPath: string;
+		entitiesPath: string;
+		entityNamePattern: string;
+	}
+}
+
 /**
  * The configuration object for the Expresso CLI.
  *
  * @property {Pattern} scaffoldPattern - The pattern to use when scaffolding files.
  * @property {string} sourceRoot - The root directory for the source files.
  * @property {boolean} opinionated - Whether or not to use the opinionated configuration.
+ * @property {IProviders} providers - Specific configuration for each provider added.
  *
  * @see [ExpressoConfig](https://expresso-ts.com/docs)
  */
@@ -18,6 +28,7 @@ interface ExpressoConfig {
   scaffoldPattern: Pattern;
   sourceRoot: string;
   opinionated: boolean;
+	providers?: IProviders;
 }
 
 export { ExpressoConfig, Pattern };

--- a/packages/core/src/common/project-config.provider.ts
+++ b/packages/core/src/common/project-config.provider.ts
@@ -1,3 +1,11 @@
+/**
+ * Enum representing different string patterns.
+ * 
+ * - LOWER_CASE: Represents strings in all lowercase letters. E.g. "hello"
+ * - KEBAB_CASE: Represents strings separated by hyphens. E.g. "hello-world"
+ * - PASCAL_CASE: Represents strings where the first letter of each word is capitalized. E.g. "HelloWorld"
+ * - CAMEL_CASE: Represents strings where the first letter of the first word is lowercase and the first letter of subsequent words are capitalized. E.g. "helloWorld"
+ */
 const enum Pattern {
   LOWER_CASE = "lowercase",
   KEBAB_CASE = "kebab-case",
@@ -5,6 +13,14 @@ const enum Pattern {
   CAMEL_CASE = "camelCase",
 }
 
+/**
+ * Interface describing configuration specific to Prisma provider.
+ *
+ * @property {string} schemaName - The name of the Prisma schema.
+ * @property {string} schemaPath - The path to the Prisma schema file.
+ * @property {string} entitiesPath - The path to the directory containing entities.
+ * @property {string} entityNamePattern - The naming convention to use for entity names.
+ */
 interface IProviders {
 	prisma?: {
 		schemaName: string;
@@ -22,7 +38,7 @@ interface IProviders {
  * @property {boolean} opinionated - Whether or not to use the opinionated configuration.
  * @property {IProviders} providers - Specific configuration for each provider added.
  *
- * @see [ExpressoConfig](https://expresso-ts.com/docs)
+ * @see [Doc](https://doc.expresso-ts.com/)
  */
 interface ExpressoConfig {
   scaffoldPattern: Pattern;


### PR DESCRIPTION
# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [x] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Please describe the current behavior that you are modifying, or link to a relevant issue.

In the current version of Expresso, the configuration for scaffolding and opinionated settings is limited to a basic setup. While this setup works well for many use cases, it lacks support for seamless integration with the Prisma provider, making it harder to manage the schema, entities, and related configurations.

Issue Number: #69 

## What is the new behavior?

Describe the new behavior or link to a relevant issue.

Now, the ExpressoConfig allow the integration of Prisma provider, allowing users to define specific settings related to the Prisma provider, such as schema location, entity paths, naming patterns, and more as requested in issue #69.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

Any other information that is important to this PR.