### PR TITLE
fix: add `options` parameter to `AppContainer`

### DIFF
--- a/packages/core/src/application/app-container.ts
+++ b/packages/core/src/application/app-container.ts
@@ -13,6 +13,9 @@ import { buildProviderModule, provide } from "inversify-binding-decorators";
 @provide(AppContainer)
 class AppContainer {
   private container!: Container;
+
+  constructor(private options?: interfaces.ContainerOptions) {}
+
   /**
    * Creates and configures a new dependency injection container.
    * @param modules - An array of ContainerModule instances to load into the container.
@@ -26,6 +29,7 @@ class AppContainer {
     this.container = new Container({
       autoBindInjectable: true,
       defaultScope,
+      ...this.options,
     });
 
     this.container.load(buildProviderModule(), ...modules);

--- a/packages/core/src/application/app-container.ts
+++ b/packages/core/src/application/app-container.ts
@@ -7,14 +7,49 @@ import {
 import { buildProviderModule, provide } from "inversify-binding-decorators";
 
 /**
+ * Interface for container options that can be passed to the AppContainer class.
+ */
+interface ContainerOptions {
+  /**
+   * The default scope for bindings in the container.
+   * It can be set to Request (default), Singleton, or Transient.
+   */
+  defaultScope?: interfaces.BindingScope;
+
+  /**
+   * Allows skipping of base class checks when working with derived classes.
+   */
+  skipBaseClassChecks?: boolean;
+}
+
+
+/**
  * The AppContainer class provides a container for managing dependency injection.
+ * It allows the creation of a container with custom options, including default binding scope
+ * and the ability to skip base class checks. The container can be loaded with multiple
+ * ContainerModule instances, facilitating modular and organized code.
+ *
+ * Usage:
+ * const appContainer = new AppContainer(options);
+ * const container = appContainer.create(modules);
+ *
  * @provide AppContainer
  */
 @provide(AppContainer)
 class AppContainer {
   private container!: Container;
+  private options: ContainerOptions;
 
-  constructor(private options?: interfaces.ContainerOptions) {}
+   /**
+   * Constructs the AppContainer instance.
+   * @param options - The options for creating the container. Can include custom default scope and skip base class checks setting.
+   */
+  constructor(options?: ContainerOptions) {
+    this.options = {
+      defaultScope: BindingScopeEnum.Request,
+      ...options,
+    }
+  }
 
   /**
    * Creates and configures a new dependency injection container.
@@ -24,14 +59,13 @@ class AppContainer {
    */
   public create(
     modules: ContainerModule[],
-    defaultScope: interfaces.BindingScope = BindingScopeEnum.Request,
   ): Container {
-    this.container = new Container({
+    const containerOptions: interfaces.ContainerOptions = {
       autoBindInjectable: true,
-      defaultScope,
       ...this.options,
-    });
+    };
 
+    this.container = new Container(containerOptions);
     this.container.load(buildProviderModule(), ...modules);
 
     return this.container;
@@ -50,7 +84,7 @@ class AppContainer {
    * @returns The container options.
    */
   public getContainerOptions(): interfaces.ContainerOptions {
-    return this.container["options"];
+    return this.container.options;
   }
 
   /**


### PR DESCRIPTION
# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [x] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## What is the new behavior?

Allows set `options` to Inversify's container or override default options defined by ExpressoTS

To do that today:
```ts
const appContainer = new AppContainer();

const container = appContainer.create([
  // Add your modules here
  UserModule
]);
/**
 * Update options AFTER call `appContainer.create`, 
 * do it before throw `TypeError: Cannot read properties of undefined (reading 'options')`
 * because Container only is instanced after `appContainer.create` is called
 */
appContainer.Container.options.skipBaseClassChecks = true;
```
More intuitive solution:
```ts
const appContainer = new AppContainer({ skipBaseClassChecks: true })

// ... code
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

Any other information that is important to this PR.