### PR TITLE
fix: remove verb should from unit tests labels

### DIFF
--- a/packages/core/test/application.spec.ts
+++ b/packages/core/test/application.spec.ts
@@ -9,7 +9,7 @@ import {
 import { IApplicationMessageToConsole } from "../src/console";
 
 describe("AppContainer", () => {
-  it("should create a container", () => {
+  it("creates a container", () => {
     // Arrange
     const appContainer = new AppContainer();
     const modules: ContainerModule[] = [];
@@ -28,7 +28,7 @@ describe("AppContainer", () => {
 });
 
 describe("Application", () => {
-  it("should create an application express inversify server", () => {
+  it("creates an application express inversify server", () => {
     // Arrange
     const mockCreate = jest.fn().mockReturnValue({});
     const mockListen = jest.fn();

--- a/packages/core/test/console.spec.ts
+++ b/packages/core/test/console.spec.ts
@@ -37,35 +37,35 @@ describe("Console", () => {
   });
 
   describe("messageServer", () => {
-    it('should call message server with the correct arguments for environment "development" without IConsoleMessage', async () => {
+    it('calls message server with the correct arguments for environment "development" without IConsoleMessage', async () => {
       const spy = jest.spyOn(console, "log");
       await consoleInstance.messageServer(3000, "development");
 
       expect(spy).toHaveBeenCalledWith("mocked yellow message");
     });
 
-    it('should call message server with the correct arguments for environment "staging" without IConsoleMessage', async () => {
+    it('calls message server with the correct arguments for environment "staging" without IConsoleMessage', async () => {
       const spy = jest.spyOn(console, "log");
       await consoleInstance.messageServer(3000, "staging");
 
       expect(spy).toHaveBeenCalledWith("mocked blue message");
     });
 
-    it('should call message server with the correct arguments for environment "production" without IConsoleMessage', async () => {
+    it('calls message server with the correct arguments for environment "production" without IConsoleMessage', async () => {
       const spy = jest.spyOn(console, "log");
       await consoleInstance.messageServer(3000, "production");
 
       expect(spy).toHaveBeenCalledWith("mocked green message");
     });
 
-    it('should call message server with the correct arguments for environment "unknown" without IConsoleMessage', async () => {
+    it('calls message server with the correct arguments for environment "unknown" without IConsoleMessage', async () => {
       const spy = jest.spyOn(console, "log");
       await consoleInstance.messageServer(3000, "test");
 
       expect(spy).toHaveBeenCalledWith("mocked red message");
     });
 
-    it('should call message server with the correct arguments when the "consoleMessage" argument is provided', async () => {
+    it('calls message server with the correct arguments when the "consoleMessage" argument is provided', async () => {
       const spy = jest.spyOn(consoleInstance, "messageServer");
       const consoleMessage = {
         appName: "TestApp",

--- a/templates/non_opinionated/test/app.usecase.spec.ts
+++ b/templates/non_opinionated/test/app.usecase.spec.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { AppUseCase } from "../src/app.usecase";
 
 describe("AppUseCase", () => {
-    it("should return Hello Expresso TS!", () => {
+    it("returns Hello Expresso TS!", () => {
         const appUseCase = new AppUseCase();
         const result = appUseCase.execute();
 

--- a/templates/opinionated/test/app.usecase.spec.ts
+++ b/templates/opinionated/test/app.usecase.spec.ts
@@ -8,7 +8,7 @@ describe("AppUseCase", () => {
         appUseCase = new AppUseCase();
     });
 
-    it("should return a valid AppResponse", () => {
+    it("returns a valid AppResponse", () => {
         const response = appUseCase.execute();
         expect(response).toBe("Hello from ExpressoTS App");
     });


### PR DESCRIPTION
closes #77 

# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [x] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Test labels starting with the verb "should".

Issue Number: #77 

## What is the new behavior?

Leaner labels using the indicative verb tense.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

N/A