### PR TITLE
fix: add non opinionated scaffold schematics name change

### DIFF
--- a/packages/core/src/common/project-config.provider.ts
+++ b/packages/core/src/common/project-config.provider.ts
@@ -45,6 +45,15 @@ interface ExpressoConfig {
   sourceRoot: string;
   opinionated: boolean;
   providers?: IProviders;
+  scaffoldSchematics?: {
+    entity?: string;
+    controller?: string;
+    usecase?: string;
+    dto?: string;
+    module?: string;
+    provider?: string;
+    middleware?: string;
+  };
 }
 
 export { ExpressoConfig, Pattern };


### PR DESCRIPTION
# Pull Request Guidelines

Our guidelines for submitting a pull request.

## Before submitting a Pull Request, please make sure you have verified the following:

- [x] The commit message follows our guidelines:
  - A good commit message should be two things: meaningful and concise. It should not contain every single detail, describing each changed line—we can see all the changes in Git—but, at the same time, it should say enough to avoid ambiguity.
  - We use Microverse's commit message convention
  - The convention stablish that a commit message has to be in the present tense, imperative and lowercase.
  - Example: `fix typo in README.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Please describe the current behavior that you are modifying, or link to a relevant issue.
Current expressots config

```typescript
interface ExpressoConfig {
  scaffoldPattern: Pattern;
  sourceRoot: string;
  opinionated: boolean;
  providers?: IProviders;
}
```
Issue Number: N/A

## What is the new behavior?
Describe the new behavior or link to a relevant issue.
New scaffold naming config
```typescript
interface ExpressoConfig {
  scaffoldPattern: Pattern;
  sourceRoot: string;
  opinionated: boolean;
  providers?: IProviders;
  scaffoldSchematics?: {
    entity?: string;
    controller?: string;
    usecase?: string;
    dto?: string;
    module?: string;
    provider?: string;
    middleware?: string;
  };
}

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications below.

## Other information

Any other information that is important to this PR.