### PR TITLE
fix(security): bump undici to 7.28.0 (Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,25 +2319,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
@@ -8876,9 +8857,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/release-it": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.0.tgz",
-      "integrity": "sha512-9ZTk9ripgctC6VTqH+P54KuboK29A5mG/I3tFfS5hnoAnkwtFFAMHRidYz93ylrW995vF50Ny1aOGJiyRmEN7w==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.1.tgz",
+      "integrity": "sha512-xd0mqTGduwQlEzVBKOJcoVZxDrRLzjmFv3W8tWwkPIPDYtwYBWYjULiSk6VhfuGKocfz7GmptAqViKMQV4Zzbw==",
       "dev": true,
       "funding": [
         {
@@ -8911,7 +8892,7 @@
         "proxy-agent": "7.0.0",
         "semver": "7.7.4",
         "tinyglobby": "0.2.15",
-        "undici": "7.24.5",
+        "undici": "7.28.0",
         "url-join": "5.0.0",
         "wildcard-match": "5.1.4",
         "yargs-parser": "22.0.0"
@@ -9974,9 +9955,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Regenerates `package-lock.json` so the transitive `undici` dependency (via `release-it`) moves from `7.24.5` to `7.28.0`.
- Clears the open `undici` Dependabot alerts (2 high + moderate/low GHSA advisories: TLS bypass, header injection, WS DoS, cache poisoning, etc.).
- `npm audit` now reports **0 vulnerabilities**.

## Changes
- `package-lock.json` only (no manifest / no runtime dependency changes).

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (339 suites, 2854 tests)
- [x] `npm audit` reports 0 vulnerabilities
- [ ] CI green on PR (clean `npm ci` install against updated lockfile)