### PR TITLE
fix(adapter): response fidelity and working lifecycle hooks on serverless targets

### DIFF
--- a/.changeset/edge-adapter-fidelity.md
+++ b/.changeset/edge-adapter-fidelity.md
@@ -1,0 +1,50 @@
+---
+"@expressots/adapter-express": minor
+"@expressots/cli": patch
+---
+
+Serverless adapters: response fidelity, working lifecycle hooks, and a loud
+guard for body-parsing middleware.
+
+**Adapters accept a `MicroApp` directly.** `cloudflareAdapter(app)`,
+`vercelAdapter(app)` and `awsLambdaAdapter(app)` now unwrap `getApp()` as well
+as `getExpressApp()`. Passing a `MicroApp` previously handed Express an object
+that was not an Express app, failing deep inside the router rather than at the
+call site. `app.getApp()` keeps working.
+
+**Response fidelity (#948).**
+
+- Multiple `Set-Cookie` headers no longer collapse into one comma-joined value,
+  which broke every cookie-based session. Cloudflare emits them via
+  `Headers.append()`; Lambda emits them in `multiValueHeaders`.
+- `res.statusCode = 201` is honoured on Cloudflare. It was tracked in a closure
+  only `res.status()` wrote to, so direct assignment — ordinary Express, and
+  what several third-party middlewares do internally — was silently dropped.
+- 204/205/304 responses carry no body. Passing an empty Buffer is tolerated by
+  workerd but throws under Node/undici, so a 204 endpoint passed in production
+  and failed in its own Jest suite.
+
+**`setErrorHandler` and the RFC-7807 404 work on serverless targets (#950).**
+Both were installed inside `listen()`, which serverless adapters never call, so
+`setErrorHandler` type-checked and did nothing. `micro()` now finalizes its
+middleware stack on the first request, so hosting makes no difference.
+Registration is idempotent, and the handler is resolved at request time so
+`setErrorHandler` still takes effect if called late.
+
+**Body-parsing middleware fails loudly instead of at runtime (#951).**
+`micro()`'s auto-parsers stand down when a Cloudflare or Lambda adapter is
+attached, so the default `micro()` config now works on Workers without
+`autoParseJson: false`. Explicitly registering `express.json()`,
+`express.urlencoded()`, `express.text()`, `express.raw()`, `multer()` or
+`compression()` on those targets throws a named error at adapter construction —
+which in a Worker is module scope, so it surfaces at `wrangler dev` startup
+rather than as a 500 on every request.
+
+`vercelAdapter` is deliberately exempt from that guard: Vercel supplies a real
+Node request/response pair, so body parsers work there normally. Its error
+responses no longer leak `err.message` to the client, matching the other
+adapters.
+
+The Cloudflare scaffold drops the now-unnecessary `autoParseJson: false` line,
+and its README and `AGENTS.md` describe the constraint rather than the
+workaround.

--- a/packages/adapter-express/src/adapter-express/micro-api/micro.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/micro.ts
@@ -17,6 +17,7 @@ import {
   reportStudioRuntimeInfo,
   rescanStudioRoutes,
 } from "../studio/index.js";
+import { SERVERLESS_HOST_SETTING } from "./serverless/serverless-app.js";
 
 /**
  * Minimal configuration for micro API
@@ -139,10 +140,38 @@ export function micro(config?: MicroConfig): MicroApp {
     next();
   });
 
-  // Auto-enable JSON parsing by default
+  // Finalize the middleware stack on the first request. `listen()` also calls
+  // this, but serverless adapters consume `getApp()` and never call `listen()`
+  // — so without a lazy trigger the 404 fallback and setErrorHandler would be
+  // dead on Cloudflare, Vercel and Lambda. Registered here, ahead of user
+  // routes, so that by the time a request falls through the stack the
+  // terminal handlers have been appended.
+  app.use((_req, _res, next) => {
+    finalize();
+    next();
+  });
+
+  // Auto-enable JSON parsing by default.
+  //
+  // The parsers are wrapped rather than registered directly: on a serverless
+  // runtime that synthesises a mock request, body-parser reaches for
+  // `req.socket` and throws on *every* request, including GETs with no body.
+  // The adapter sets SERVERLESS_HOST_SETTING at construction, and these stand
+  // down — the adapter has already parsed the body by then, so nothing is
+  // lost. The wrapper name matters: it must not collide with the names
+  // `prepareServerlessApp` rejects, or micro's own parsers would trip its
+  // guard.
   if (config?.autoParseJson !== false) {
-    app.use(express.json());
-    app.use(express.urlencoded({ extended: true }));
+    const parsers = [express.json(), express.urlencoded({ extended: true })];
+
+    for (const parser of parsers) {
+      app.use(function expressotsAutoParser(req, res, next) {
+        if (app.get(SERVERLESS_HOST_SETTING)) {
+          return next();
+        }
+        return parser(req, res, next);
+      });
+    }
   }
 
   /**
@@ -269,6 +298,47 @@ export function micro(config?: MicroConfig): MicroApp {
   };
 
   /**
+   * Append the terminal middleware — the 404 fallback and the error handler —
+   * exactly once, whatever is hosting the app.
+   *
+   * This used to live inline in `listen()`, which meant every serverless
+   * target silently lost both: adapters consume `getApp()` and never listen.
+   * `setErrorHandler` type-checked and did nothing, and unmatched routes fell
+   * through to whatever the adapter did on its own.
+   */
+  let finalized = false;
+  const finalize = (): void => {
+    if (finalized) {
+      return;
+    }
+    finalized = true;
+
+    // 404 fallback first, so unmatched routes get suggestions instead of
+    // falling through to Express's default HTML — or worse, to a regular
+    // middleware that arity-confused its way into running on every request.
+    installNotFoundHandler();
+
+    // Then the error handler, always registered with 4 arity so Express
+    // recognises it as error-handling regardless of whether the user wrote
+    // `(err, req, res)` or `(err, req, res, next)`. Without the wrapper,
+    // Express would treat a 3-arg user handler as ordinary middleware and run
+    // it on every request, swallowing 404s and crashing when the user calls
+    // `res.status(...)` (positional `res` would actually be Express's `next`).
+    //
+    // Registered unconditionally and resolved at call time, so
+    // `setErrorHandler()` still takes effect when it is called after the
+    // stack has been finalized. With no handler set, `next(err)` restores
+    // Express's default behaviour exactly.
+    const wrappedErrorHandler: express.ErrorRequestHandler = (err, req, res, next) => {
+      if (!errorHandler) {
+        return next(err);
+      }
+      return errorHandler(err, req, res, next);
+    };
+    app.use(wrappedErrorHandler);
+  };
+
+  /**
    * Handle server shutdown. In development, exit immediately for fast
    * hot-reload. In production, drain connections before exiting.
    */
@@ -333,25 +403,9 @@ export function micro(config?: MicroConfig): MicroApp {
         }
       }
 
-      // Install the 404 fallback before the user error handler so unmatched
-      // routes get suggestions instead of falling through to the default
-      // Express HTML or - worse - to a regular middleware that arity-confused
-      // its way into running on every request.
-      installNotFoundHandler();
-
-      // Apply error handler last. Wrap it in a 4-arity function so that
-      // Express recognizes it as an error-handling middleware regardless of
-      // whether the user wrote `(err, req, res)` or `(err, req, res, next)`.
-      // Without this wrapper, Express would treat a 3-arg user handler as a
-      // regular middleware and run it on every request, which both swallows
-      // 404s and crashes when the user calls `res.status(...)` (positional
-      // `res` would actually be Express's `next`).
-      if (errorHandler) {
-        const userHandler = errorHandler;
-        const wrappedErrorHandler: express.ErrorRequestHandler = (err, req, res, next) =>
-          userHandler(err, req, res, next);
-        app.use(wrappedErrorHandler);
-      }
+      // Append the 404 fallback and error handler. Idempotent, so a request
+      // that already triggered the lazy finalize does not double-register.
+      finalize();
 
       return new Promise((resolve, reject) => {
         httpServer = app.listen(normalizedPort, async () => {

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/aws-lambda.adapter.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/aws-lambda.adapter.ts
@@ -4,7 +4,7 @@
  * Converts Lambda events to Express requests and responses.
  */
 
-import { Application } from "express";
+import { prepareServerlessApp, resolveExpressApp, ServerlessApp } from "./serverless-app.js";
 
 /**
  * AWS Lambda Event (simplified)
@@ -42,6 +42,12 @@ export interface LambdaContext {
 export interface LambdaResponse {
   statusCode: number;
   headers: Record<string, string>;
+  /**
+   * Headers that legitimately repeat — `Set-Cookie` above all. API Gateway
+   * merges this with `headers`, so a header appears in exactly one of the
+   * two, never both. Only present when some header was set more than once.
+   */
+  multiValueHeaders?: Record<string, Array<string>>;
   body: string;
   isBase64Encoded: boolean;
 }
@@ -79,12 +85,12 @@ export interface LambdaAdapterConfig {
  * export const handler = awsLambdaAdapter(app);
  * ```
  */
-export function awsLambdaAdapter(
-  app: { getExpressApp?: () => Application } | Application,
-  config?: LambdaAdapterConfig,
-): LambdaHandler {
-  const expressApp =
-    "getExpressApp" in app && app.getExpressApp ? app.getExpressApp() : (app as Application);
+export function awsLambdaAdapter(app: ServerlessApp, config?: LambdaAdapterConfig): LambdaHandler {
+  const expressApp = resolveExpressApp(app);
+
+  // Like Cloudflare, this adapter hands Express a mock request rather than a
+  // stream, so body-reading middleware cannot work here either.
+  prepareServerlessApp(expressApp, "awsLambdaAdapter");
 
   const binaryTypes = config?.binaryContentTypes ?? [
     "application/octet-stream",
@@ -159,17 +165,40 @@ export function awsLambdaAdapter(
         get: (name: string) => headers[name.toLowerCase()],
       };
 
-      // Create mock Express-compatible response object
+      // Create mock Express-compatible response object.
       const chunks: Array<Buffer> = [];
-      const responseHeaders: Record<string, string> = {};
+
+      // Values are kept as arrays so repeatable headers survive. A plain
+      // Record silently collapses two Set-Cookie calls into one malformed
+      // header, which breaks any cookie-based session.
+      const headerValues = new Map<string, Array<string>>();
+      const appendHeader = (name: string, value: string | Array<string>): void => {
+        const key = name.toLowerCase();
+        const existing = headerValues.get(key) ?? [];
+        for (const entry of Array.isArray(value) ? value : [value]) {
+          existing.push(String(entry));
+        }
+        headerValues.set(key, existing);
+      };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const res: any = {
         statusCode: 200,
-        setHeader: (name: string, value: string) => {
-          responseHeaders[name.toLowerCase()] = value;
+        setHeader: (name: string, value: string | Array<string>) => {
+          headerValues.delete(name.toLowerCase());
+          appendHeader(name, value);
         },
-        getHeader: (name: string) => responseHeaders[name.toLowerCase()],
+        appendHeader: (name: string, value: string | Array<string>) => {
+          appendHeader(name, value);
+        },
+        getHeader: (name: string) => {
+          const values = headerValues.get(name.toLowerCase());
+          if (!values) return undefined;
+          return values.length > 1 ? values : values[0];
+        },
+        removeHeader: (name: string) => {
+          headerValues.delete(name.toLowerCase());
+        },
         write: (chunk: string | Buffer) => {
           chunks.push(Buffer.from(chunk));
         },
@@ -179,7 +208,7 @@ export function awsLambdaAdapter(
           }
 
           const bodyBuffer = Buffer.concat(chunks);
-          const contentType = responseHeaders["content-type"] || "";
+          const contentType = headerValues.get("content-type")?.[0] || "";
           const isBinary = binaryTypes.some((type) => {
             if (type.endsWith("/*")) {
               return contentType.startsWith(type.replace("/*", "/"));
@@ -187,9 +216,22 @@ export function awsLambdaAdapter(
             return contentType === type;
           });
 
+          // A header goes in exactly one of the two maps: API Gateway merges
+          // them, so listing a value in both would emit it twice.
+          const responseHeaders: Record<string, string> = {};
+          const multiValueHeaders: Record<string, Array<string>> = {};
+          headerValues.forEach((values, name) => {
+            if (values.length > 1) {
+              multiValueHeaders[name] = values;
+            } else {
+              responseHeaders[name] = values[0];
+            }
+          });
+
           const response: LambdaResponse = {
             statusCode: res.statusCode,
             headers: responseHeaders,
+            ...(Object.keys(multiValueHeaders).length > 0 ? { multiValueHeaders } : {}),
             body: isBinary ? bodyBuffer.toString("base64") : bodyBuffer.toString("utf8"),
             isBase64Encoded: isBinary,
           };

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.spec.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.spec.ts
@@ -1,3 +1,4 @@
+import express from "express";
 import { micro } from "../micro";
 import { cloudflareAdapter, CloudflareContext, CloudflareHandler } from "./cloudflare.adapter";
 
@@ -87,6 +88,34 @@ describe("cloudflareAdapter request bodies", () => {
 
     expect(response.status).toBe(404);
     expect(response.headers.get("content-type")).toBe("application/json");
+
+    // micro() finalizes its middleware stack on the first request now, so the
+    // RFC-7807 body reaches serverless targets too rather than being wired
+    // only inside listen(). The adapter's plain {"error":"Not Found"} remains
+    // as defence in depth for apps that are not micro apps.
+    expect(await response.json()).toMatchObject({
+      type: "https://expressots.dev/errors/not-found",
+      title: "Route Not Found",
+      status: 404,
+      detail: "Route 'POST /missing' does not exist",
+      instance: "/missing",
+    });
+  }, 1000);
+
+  it("still falls back to a plain 404 when the app is not a micro app", async () => {
+    const bareApp = express();
+    bareApp.post("/echo", (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const worker = cloudflareAdapter(bareApp);
+    const response = await worker.fetch(
+      new Request("https://worker.example/missing", { method: "POST" }),
+      {},
+      context,
+    );
+
+    expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "Not Found" });
   }, 1000);
 
@@ -127,5 +156,147 @@ describe("cloudflareAdapter request bodies", () => {
     expect(await response.json()).toEqual({
       body: { name: "Jane Doe", role: "admin" },
     });
+  });
+});
+
+describe("cloudflareAdapter response fidelity", () => {
+  function workerFor(register: (app: ReturnType<typeof micro>) => void): CloudflareHandler {
+    const app = micro({
+      autoParseJson: false,
+      showBanner: false,
+      studio: { enabled: false },
+    });
+    register(app);
+    return cloudflareAdapter(app.getApp());
+  }
+
+  it("emits one Set-Cookie header per cookie instead of collapsing them", async () => {
+    const worker = workerFor((app) => {
+      app.get("/cookies", (_req, res) => {
+        res.cookie("a", "1");
+        res.cookie("b", "2");
+        return { ok: true };
+      });
+    });
+
+    const response = await worker.fetch(new Request("https://worker.example/cookies"), {}, context);
+
+    // getSetCookie() is the only accessor that exposes the individual
+    // entries; get() joins them, which is exactly the bug being guarded.
+    const cookies = response.headers.getSetCookie();
+    expect(cookies).toHaveLength(2);
+    expect(cookies[0]).toContain("a=1");
+    expect(cookies[1]).toContain("b=2");
+  });
+
+  it("honours a directly assigned res.statusCode", async () => {
+    const worker = workerFor((app) => {
+      app.get("/created", (_req, res) => {
+        res.statusCode = 201;
+        return { ok: true };
+      });
+    });
+
+    const response = await worker.fetch(new Request("https://worker.example/created"), {}, context);
+
+    expect(response.status).toBe(201);
+  });
+
+  it.each([204, 205, 304])("returns %i without a body under Node/undici", async (status) => {
+    const worker = workerFor((app) => {
+      app.get("/empty", (_req, res) => {
+        res.status(status).end();
+      });
+    });
+
+    const response = await worker.fetch(new Request("https://worker.example/empty"), {}, context);
+
+    // Passing even an empty Buffer for these statuses throws in undici and
+    // would surface as a 500 from the adapter's catch-all.
+    expect(response.status).toBe(status);
+    expect(response.body).toBeNull();
+  });
+});
+
+describe("cloudflareAdapter serverless guards", () => {
+  it("serves requests with micro()'s default auto-parsing enabled", async () => {
+    // No autoParseJson: false — the adapter must stand the parsers down
+    // itself, or body-parser reaches for req.socket and 500s every request.
+    const app = micro({ showBanner: false, studio: { enabled: false } });
+    app.post("/echo", (request) => ({ body: request.body }));
+
+    const worker = cloudflareAdapter(app);
+    const response = await worker.fetch(
+      new Request("https://worker.example/echo", {
+        method: "POST",
+        headers: { "content-type": "application/json", "content-length": "13" },
+        body: JSON.stringify({ hi: "there" }),
+      }),
+      {},
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ body: { hi: "there" } });
+  });
+
+  it("throws a named error when stream-reading middleware is registered", () => {
+    const app = micro({
+      autoParseJson: false,
+      showBanner: false,
+      studio: { enabled: false },
+    });
+    app.use(express.json());
+
+    expect(() => cloudflareAdapter(app)).toThrow(/cloudflareAdapter: express\.json\(\)/);
+    expect(() => cloudflareAdapter(app)).toThrow(/req\.body/);
+  });
+
+  it("accepts a MicroApp, an app.getApp() result, and a bare express app", async () => {
+    const build = (): ReturnType<typeof micro> => {
+      const app = micro({
+        autoParseJson: false,
+        showBanner: false,
+        studio: { enabled: false },
+      });
+      app.get("/", () => ({ ok: true }));
+      return app;
+    };
+
+    const bare = express();
+    bare.get("/", (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    for (const handler of [
+      cloudflareAdapter(build()),
+      cloudflareAdapter(build().getApp()),
+      cloudflareAdapter(bare),
+    ]) {
+      const response = await handler.fetch(new Request("https://worker.example/"), {}, context);
+      expect(await response.json()).toEqual({ ok: true });
+    }
+  });
+});
+
+describe("micro() finalize outside listen()", () => {
+  it("runs setErrorHandler on a serverless target", async () => {
+    const app = micro({
+      autoParseJson: false,
+      showBanner: false,
+      studio: { enabled: false },
+    });
+    app.get("/boom", () => {
+      throw new Error("nope");
+    });
+    app.setErrorHandler((_err, _req, res, _next) => {
+      res.status(418).json({ handled: true });
+    });
+
+    const worker = cloudflareAdapter(app);
+    const response = await worker.fetch(new Request("https://worker.example/boom"), {}, context);
+
+    expect(response.status).toBe(418);
+    expect(await response.json()).toEqual({ handled: true });
   });
 });

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.ts
@@ -6,7 +6,12 @@
  * or uses a fetch-based approach.
  */
 
-import { Application } from "express";
+import {
+  NULL_BODY_STATUSES,
+  prepareServerlessApp,
+  resolveExpressApp,
+  ServerlessApp,
+} from "./serverless-app.js";
 
 /**
  * Cloudflare Workers Environment bindings
@@ -73,11 +78,14 @@ export interface CloudflareAdapterConfig {
  * ```
  */
 export function cloudflareAdapter(
-  app: { getExpressApp?: () => Application } | Application,
+  app: ServerlessApp,
   config?: CloudflareAdapterConfig,
 ): CloudflareHandler {
-  const expressApp =
-    "getExpressApp" in app && app.getExpressApp ? app.getExpressApp() : (app as Application);
+  const expressApp = resolveExpressApp(app);
+
+  // Runs at module scope in a Worker, so an unusable middleware stack fails
+  // at `wrangler dev` startup / deploy rather than as a 500 per request.
+  prepareServerlessApp(expressApp, "cloudflareAdapter");
 
   const debug = config?.debug ?? false;
 
@@ -153,18 +161,41 @@ export function cloudflareAdapter(
           cloudflare: { env, ctx },
         };
 
-        // Create mock Express-compatible response object
+        // Create mock Express-compatible response object.
         const chunks: Array<Buffer> = [];
-        const responseHeaders: Record<string, string> = {};
+
+        // Values are kept as arrays so repeatable headers survive. Set-Cookie
+        // is the one that matters: a Record collapses two cookies into one
+        // comma-joined value, which breaks every cookie-based session. The
+        // Headers object is built from this at the end, via append().
+        const headerValues = new Map<string, Array<string>>();
+        const appendHeader = (name: string, value: string | Array<string>): void => {
+          const key = name.toLowerCase();
+          const existing = headerValues.get(key) ?? [];
+          for (const entry of Array.isArray(value) ? value : [value]) {
+            existing.push(String(entry));
+          }
+          headerValues.set(key, existing);
+        };
         let statusCode = 200;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const res: any = {
-          statusCode: 200,
-          setHeader: (name: string, value: string) => {
-            responseHeaders[name.toLowerCase()] = value;
+          setHeader: (name: string, value: string | Array<string>) => {
+            headerValues.delete(name.toLowerCase());
+            appendHeader(name, value);
           },
-          getHeader: (name: string) => responseHeaders[name.toLowerCase()],
+          appendHeader: (name: string, value: string | Array<string>) => {
+            appendHeader(name, value);
+          },
+          getHeader: (name: string) => {
+            const values = headerValues.get(name.toLowerCase());
+            if (!values) return undefined;
+            return values.length > 1 ? values : values[0];
+          },
+          removeHeader: (name: string) => {
+            headerValues.delete(name.toLowerCase());
+          },
           write: (chunk: string | Buffer) => {
             chunks.push(Buffer.from(chunk));
           },
@@ -175,16 +206,33 @@ export function cloudflareAdapter(
 
             const bodyBuffer = Buffer.concat(chunks);
 
+            // append() rather than the Headers constructor, so a header set
+            // more than once emits more than once.
+            const responseHeaders = new globalThis.Headers();
+            headerValues.forEach((values, name) => {
+              for (const value of values) {
+                responseHeaders.append(name, value);
+              }
+            });
+
             if (debug) {
+              const debugHeaders: Record<string, Array<string>> = {};
+              headerValues.forEach((values, name) => {
+                debugHeaders[name] = values;
+              });
               console.log("[Cloudflare] Response:", {
                 statusCode,
-                headers: responseHeaders,
+                headers: debugHeaders,
                 bodyLength: bodyBuffer.length,
               });
             }
 
+            // 204/205/304 and friends must carry no body at all. workerd
+            // tolerates an empty Buffer here, but Node/undici throws — which
+            // would make a 204 endpoint pass in production and fail in its
+            // own Jest suite.
             resolve(
-              new globalThis.Response(bodyBuffer, {
+              new globalThis.Response(NULL_BODY_STATUSES.has(statusCode) ? null : bodyBuffer, {
                 status: statusCode,
                 headers: responseHeaders,
               }),
@@ -209,6 +257,19 @@ export function cloudflareAdapter(
             }
           },
         };
+
+        // `res.statusCode = 201` is ordinary Express, and several third-party
+        // middlewares set it directly rather than calling res.status(). Back
+        // it with the same storage res.status() writes to, or the assignment
+        // is silently dropped and the response goes out as 200.
+        Object.defineProperty(res, "statusCode", {
+          get: () => statusCode,
+          set: (code: number) => {
+            statusCode = code;
+          },
+          enumerable: true,
+          configurable: true,
+        });
 
         // Handle request through Express
         try {

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/serverless-app.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/serverless-app.ts
@@ -1,0 +1,118 @@
+import { Application } from "express";
+
+/**
+ * Anything the serverless adapters accept as "the app".
+ *
+ * `micro()` returns a `MicroApp` whose Express instance is behind `getApp()`.
+ * The full `AppExpress` surface exposes `getExpressApp()`. Passing a raw
+ * `express.Application` is also supported. Accepting all three means users do
+ * not have to remember which unwrapping call their host expects — passing the
+ * wrong one used to hand Express an object that is not an Express app at all,
+ * which fails deep inside the router rather than at the call site.
+ */
+export type ServerlessApp =
+  { getExpressApp?: () => Application } | { getApp?: () => Application } | Application;
+
+/**
+ * Statuses whose responses must not carry a body. Passing even an empty
+ * Buffer for these throws `TypeError: Invalid response status code` under
+ * Node/undici, while workerd tolerates it — so a 204 endpoint would pass in
+ * production and fail in its own Jest suite.
+ */
+export const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+
+/**
+ * Express middleware that reads the request body as a stream. None of these
+ * can work on an edge runtime, because the adapters hand Express a plain
+ * mock object rather than a `Readable`. Matched by function name, which is
+ * how `body-parser` and friends identify their own middleware.
+ */
+const STREAM_READING_MIDDLEWARE: Record<string, string> = {
+  jsonParser: "express.json()",
+  urlencodedParser: "express.urlencoded()",
+  textParser: "express.text()",
+  rawParser: "express.raw()",
+  multerMiddleware: "multer()",
+  compression: "compression()",
+};
+
+/**
+ * Express setting used to tell `micro()` that it is being hosted on a
+ * serverless runtime. Stored on the Express app rather than on the `MicroApp`
+ * wrapper so it survives being passed as `app.getApp()` — the adapter can set
+ * it whichever form it was handed.
+ */
+export const SERVERLESS_HOST_SETTING = "expressots:serverless-host";
+
+export function resolveExpressApp(app: ServerlessApp): Application {
+  if ("getExpressApp" in app && typeof app.getExpressApp === "function") {
+    return app.getExpressApp();
+  }
+
+  if ("getApp" in app && typeof app.getApp === "function") {
+    return app.getApp();
+  }
+
+  return app as Application;
+}
+
+/**
+ * Mark the app as serverless-hosted so `micro()`'s auto-parsers stand down,
+ * then reject any body-reading middleware the user registered explicitly.
+ *
+ * Called at adapter construction, which in a Worker is module scope — so the
+ * failure surfaces at `wrangler dev` startup or deploy time rather than as a
+ * 500 on every request once real traffic arrives.
+ */
+export function prepareServerlessApp(app: Application, hostName: string): void {
+  // A bare request handler is a legitimate thing to pass here — tests stub
+  // one, and `app.use`-less mini-apps exist in the wild. Only a real Express
+  // application carries settings, so probe rather than assume.
+  if (typeof (app as Partial<Application>).set === "function") {
+    app.set(SERVERLESS_HOST_SETTING, true);
+  }
+
+  const offender = findStreamReadingMiddleware(app);
+  if (offender) {
+    throw new Error(
+      `${hostName}: ${offender} cannot be used on this runtime.\n` +
+        `The adapter parses the request body and hands Express a mock request, ` +
+        `not a stream, so body-reading middleware fails on every request — ` +
+        `including GET requests with no body.\n` +
+        `Read parsed data from req.body instead, and remove the middleware. ` +
+        `micro()'s built-in parsers are disabled automatically on this runtime.`,
+    );
+  }
+}
+
+function findStreamReadingMiddleware(app: Application): string | undefined {
+  // Express 5 exposes `app.router`; Express 4 used the lazily-built
+  // `app._router`. Neither is public API, so every access is defensive:
+  // a missing stack must mean "nothing to check", never a crash at import
+  // time in a Worker.
+  const router = (
+    app as unknown as {
+      router?: { stack?: Array<{ handle?: { name?: string } }> };
+      _router?: { stack?: Array<{ handle?: { name?: string } }> };
+    }
+  ).router;
+  const legacyRouter = (
+    app as unknown as {
+      _router?: { stack?: Array<{ handle?: { name?: string } }> };
+    }
+  )._router;
+
+  const stack = router?.stack ?? legacyRouter?.stack;
+  if (!Array.isArray(stack)) {
+    return undefined;
+  }
+
+  for (const layer of stack) {
+    const name = layer?.handle?.name;
+    if (name && name in STREAM_READING_MIDDLEWARE) {
+      return STREAM_READING_MIDDLEWARE[name];
+    }
+  }
+
+  return undefined;
+}

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/vercel.adapter.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/vercel.adapter.ts
@@ -4,7 +4,8 @@
  * Converts Vercel serverless function requests to Express format.
  */
 
-import { Application, Request, Response } from "express";
+import { Request, Response } from "express";
+import { resolveExpressApp, ServerlessApp } from "./serverless-app.js";
 
 /**
  * Vercel Request type - extends Express Request with Vercel-specific properties
@@ -57,13 +58,14 @@ export interface VercelAdapterConfig {
  * }
  * ```
  */
-export function vercelAdapter(
-  app: { getExpressApp?: () => Application } | Application,
-  config?: VercelAdapterConfig,
-): VercelHandler {
-  const expressApp =
-    "getExpressApp" in app && app.getExpressApp ? app.getExpressApp() : (app as Application);
+export function vercelAdapter(app: ServerlessApp, config?: VercelAdapterConfig): VercelHandler {
+  const expressApp = resolveExpressApp(app);
 
+  // Deliberately no `prepareServerlessApp` here. Vercel hands the function a
+  // real Node IncomingMessage/ServerResponse pair, so `express.json()` and
+  // friends work normally — unlike the Cloudflare and Lambda adapters, which
+  // synthesise a mock request. Disabling the parsers here would break working
+  // deployments.
   const debug = config?.debug ?? false;
 
   return async (req: VercelRequest, res: VercelResponse): Promise<void> => {
@@ -121,17 +123,15 @@ export function vercelAdapter(
         expressApp(req as Request, res as Response, (err: unknown) => {
           if (err) {
             console.error("[Vercel] Express error:", err);
-            res.status(500).json({
-              error: err instanceof Error ? err.message : "Unknown error",
-            });
+            // Details stay in the log; the response body must not leak
+            // internal error messages or stack fragments to the client.
+            res.status(500).json({ error: "Internal Server Error" });
             resolve();
           }
         });
       } catch (error: unknown) {
         console.error("[Vercel] Handler error:", error);
-        res.status(500).json({
-          error: error instanceof Error ? error.message : "Unknown error",
-        });
+        res.status(500).json({ error: "Internal Server Error" });
         resolve();
       }
     });

--- a/packages/cli/src/new/cloudflare-target.ts
+++ b/packages/cli/src/new/cloudflare-target.ts
@@ -33,7 +33,6 @@ export interface CloudflareTargetOptions {
 const CLOUDFLARE_API_SOURCE = `import { cloudflareAdapter, micro } from "@expressots/adapter-express";
 
 const app = micro({
-    autoParseJson: false,
     showBanner: false,
     studio: { enabled: false },
 });
@@ -117,17 +116,18 @@ functional style. No DI container. Runs on workerd, not Node.js.
 
 ## Hard constraints on this target
 
-- **Never remove \`autoParseJson: false\` from \`micro()\`.** The adapter parses
-  the request body before Express sees it and hands Express a mock request
-  rather than a stream. Any stream-reading middleware — \`express.json()\`,
-  \`express.urlencoded()\`, \`express.text()\`, \`express.raw()\` — makes *every*
-  route fail at runtime, including GET. Read request data from \`req.body\`.
+- **Never add Express body-parsing middleware.** The adapter parses the
+  request body before Express sees it and hands Express a mock request rather
+  than a stream. \`express.json()\`, \`express.urlencoded()\`, \`express.text()\`,
+  \`express.raw()\`, \`multer()\` and \`compression()\` cannot run here. Read
+  request data from \`req.body\`. \`micro()\`'s own parsers are disabled
+  automatically on this runtime; registering one explicitly throws a named
+  error at startup rather than failing per request.
 - **Never call \`app.listen()\`.** Workers has no HTTP port; the runtime invokes
-  the exported \`fetch\` handler. There is no \`ex dev\` / \`ex prod\` here and
+  the exported \`fetch\` handler. There is no \`ex dev\` here and
   \`@expressots/cli\` is not a dependency of this project.
-- **\`app.setErrorHandler()\` is not wired on this target** because it is
-  installed inside \`listen()\`. Handle expected errors inside route handlers;
-  unexpected ones return a generic 500.
+- **Responses are buffered, not streamed.** The adapter collects the whole
+  body before returning it.
 - **No \`.env\` files.** Configuration comes from \`wrangler.toml\` vars and
   secrets, reachable through the bindings on the request context.
 - Request bodies are parsed by content type: JSON and \`application/*+json\`
@@ -184,20 +184,20 @@ function createCloudflareReadme(packageManager: string): string {
 This ExpressoTS micro API runs on Cloudflare Workers through Wrangler.
 
 > [!IMPORTANT]
-> Keep \`autoParseJson: false\` in \`src/api.ts\`. The Cloudflare adapter parses
-> request bodies before passing them to Express. Stream-reading middleware such
-> as \`express.json()\`, \`express.urlencoded()\`, \`express.text()\`, and
-> \`express.raw()\` is not supported by this target and can make requests fail at
-> runtime.
+> Express body-parsing middleware does not work on this target. The adapter
+> reads and parses the request body itself, then hands Express a mock request
+> rather than a stream — so \`express.json()\`, \`express.urlencoded()\`,
+> \`express.text()\`, \`express.raw()\`, \`multer()\` and \`compression()\` cannot
+> run here. Read parsed data from \`req.body\` instead.
 
 ## Known constraints
 
 - Read parsed request data from \`req.body\`; do not add Express body parsers.
-- \`app.setErrorHandler()\` is not wired for Workers because the serverless
-  handler does not call \`app.listen()\`. Until
-  [#950](https://github.com/expressots/expressots/issues/950) is resolved,
-  handle expected errors in route handlers. Unexpected errors return a generic
-  500 response.
+  \`micro()\`'s built-in parsers stand down automatically on this runtime, and
+  registering one yourself fails at \`wrangler dev\` startup with a named error
+  rather than silently returning 500 on every request.
+- Streaming responses are not supported; the adapter buffers the full body
+  before returning it.
 
 ## Install
 

--- a/packages/cli/test/new/cloudflare-scaffold.spec.ts
+++ b/packages/cli/test/new/cloudflare-scaffold.spec.ts
@@ -123,8 +123,8 @@ describe("Cloudflare target validation", () => {
 		expect(readme).toContain("wrangler dev");
 		expect(readme).toContain("ex dev");
 		expect(readme).toContain("nodejs_compat");
-		expect(readme).toContain("autoParseJson: false");
-		expect(readme).toContain("app.setErrorHandler()");
+		expect(readme).toContain("Express body-parsing middleware does not work");
+		expect(readme).toContain("do not add Express body parsers");
 		expect(readme).not.toMatch(/\bprod\b/);
 		expect(readme).not.toContain("3000");
 		expect(readme).not.toContain("app.listen(3000)");
@@ -157,7 +157,7 @@ describe("Cloudflare target validation", () => {
 			"utf8",
 		);
 		expect(agents).toContain("Cloudflare Workers");
-		expect(agents).toContain("autoParseJson: false");
+		expect(agents).toContain("Never add Express body-parsing middleware");
 		expect(agents).not.toContain("npm run prod");
 		const gitignore = fs.readFileSync(
 			path.join(projectDir, ".gitignore"),

--- a/packages/cli/test/new/cloudflare-target.spec.ts
+++ b/packages/cli/test/new/cloudflare-target.spec.ts
@@ -142,7 +142,7 @@ describe("applyCloudflareTarget", () => {
 		);
 		expect(api).toContain("cloudflareAdapter");
 		expect(api).toContain("cloudflareAdapter(app.getApp())");
-		expect(api).toContain("autoParseJson: false");
+		expect(api).not.toContain("autoParseJson");
 		expect(api).not.toContain("app.listen");
 
 		const workerTest = fs.readFileSync(
@@ -245,9 +245,9 @@ describe("applyCloudflareTarget", () => {
 
 		// ...and the Worker constraints must be stated, since this is the
 		// first file a coding agent reads.
-		expect(agents).toContain("autoParseJson: false");
+		expect(agents).toContain("Never add Express body-parsing middleware");
 		expect(agents).toContain("Never call `app.listen()`");
-		expect(agents).toContain("setErrorHandler");
+		expect(agents).toContain("Responses are buffered, not streamed");
 		expect(agents).toContain("cloudflareAdapter(app.getApp())");
 	});
 
@@ -395,8 +395,8 @@ describe("applyCloudflareTarget", () => {
 			expect(readme).toContain("ex dev");
 			expect(readme).toContain("dry-run");
 			expect(readme).toContain("nodejs_compat");
-			expect(readme).toContain("autoParseJson: false");
-			expect(readme).toContain("app.setErrorHandler()");
+			expect(readme).toContain("Express body-parsing middleware does not work");
+			expect(readme).toContain("do not add Express body parsers");
 			expect(readme).not.toContain("## Learn more");
 			expect(readme).not.toMatch(/\bprod\b/);
 			expect(readme).not.toContain("3000");


### PR DESCRIPTION
:black_heart:

## Before submitting your PR, please verify the following:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated

## PR Type

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Test
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What was changed?

The three contained follow-ups from the #946 review. Every item below was verified against a live `workerd` instance via `wrangler dev`, not just unit tests.

Closes #948
Closes #950
Closes #951

### Adapters accept a `MicroApp` directly

`cloudflareAdapter(app)`, `vercelAdapter(app)` and `awsLambdaAdapter(app)` now unwrap `getApp()` as well as `getExpressApp()`.

This was a real bug, not ergonomics: `micro()` returns a `MicroApp` that exposes `getApp()`, while all three adapters only checked for `getExpressApp()` and otherwise cast the argument to `Application`. Passing a `MicroApp` therefore handed Express an object that is not an Express app, failing deep inside the router rather than at the call site. Our own documentation did exactly this in **all four** serverless snippets. `app.getApp()` keeps working.

### Response fidelity — #948

| Behaviour | Before | After |
|---|---|---|
| Two `res.cookie()` calls | `Set-Cookie: a=1; Path=/,b=2; Path=/` | Two distinct `Set-Cookie` headers |
| `res.statusCode = 201` | `200` | `201` |
| `res.status(204).end()` | 500 under Node/undici | `204` with a null body |

- **Set-Cookie** — headers are collected as arrays; Cloudflare emits them through `Headers.append()`, Lambda through `multiValueHeaders` (with each header in exactly one of the two maps, since API Gateway merges them). A comma-joined `Set-Cookie` breaks every cookie-based session.
- **`res.statusCode`** — was tracked in a closure only `res.status()` wrote to, so direct assignment was silently dropped. Now an accessor backed by the same storage. Several third-party middlewares set it this way.
- **Null-body statuses** — passing an empty `Buffer` for 204/205/304 is tolerated by workerd but throws under undici, so a 204 endpoint passed in production and failed in its own Jest suite. That is the worst direction for a divergence to point.

### `setErrorHandler` and the RFC-7807 404 work on serverless targets — #950

Both were installed inside `listen()`, which no serverless adapter ever calls. `setErrorHandler` type-checked and did nothing — worse than a missing feature, because `AGENTS.md` instructs users to use it.

`micro()` now finalizes its middleware stack on the first request. Registration is idempotent (`listen()` still calls it), ordering is unchanged (404 fallback before the error handler, both after user routes), and the error handler is resolved at request time so `setErrorHandler` still takes effect when called after finalization. With no handler set, `next(err)` restores Express's default behaviour exactly.

The adapter-level `{"error":"Not Found"}` from #946 remains as defence in depth for apps that are not micro apps — covered by a test.

### Body-parsing middleware fails loudly — #951

`micro()`'s auto-parsers stand down when a mock-request adapter is attached, so **the default `micro()` config now works on Workers with no `autoParseJson: false`**. The flag is signalled through an Express setting rather than the `MicroApp` wrapper, so it works whether the adapter was handed `app` or `app.getApp()`.

Explicitly registering `express.json()`, `express.urlencoded()`, `express.text()`, `express.raw()`, `multer()` or `compression()` now throws at adapter construction — module scope in a Worker, so it surfaces at startup:

```
✘ [ERROR] service core:user:edge-api: Uncaught Error: cloudflareAdapter:
  express.json() cannot be used on this runtime.
  The adapter parses the request body and hands Express a mock request, not a
  stream, so body-reading middleware fails on every request — including GET
  requests with no body.
  Read parsed data from req.body instead, and remove the middleware.
```

Previously this returned 500 on every request, and **passed under Jest**, because undici omits `content-length` and body-parser short-circuits.

### Two deviations from the issues, deliberate

1. **`vercelAdapter` is exempt from the parser guard**, contrary to #951's acceptance criterion. That criterion assumed Vercel shares the mock design — it does not. Vercel supplies a real Node `IncomingMessage`/`ServerResponse` pair, so `express.json()` works there normally and the guard would break working deployments. Same reason #948's response fixes do not apply to it.
2. **`vercelAdapter` no longer leaks `err.message`** to the client in its 500 path — an unrelated leak found while auditing it, now matching the other two adapters.

### Scaffold

The Cloudflare scaffold drops the now-unnecessary `autoParseJson: false` line, and its README and `AGENTS.md` describe the constraint rather than the workaround — they previously said *"never remove `autoParseJson: false`"*, which this PR makes wrong.

## Other information

**Verified on a live workerd instance** (`wrangler dev`, real HTTP traffic):

```
GET  /            200          default micro(), no autoParseJson: false
POST /echo        {"type":"object","body":{"a":1}}
GET  /cookies     Set-Cookie: a=1; Path=/
                  Set-Cookie: b=2; Path=/
GET  /created     201          res.statusCode = 201
DELETE /item      204
GET  /boom        418 {"handled":true}          setErrorHandler
GET  /nope        RFC-7807 body with suggestions
```

Plus `app.use(express.json())` refusing to boot workerd, as above.

**Gates:** `build` / `lint` / `test` green across the monorepo — adapter-express **403** (+10 new), cli 548, core 2812, shared 68, boost-ts 3.

Documentation for this behaviour is in `expressots/expresso-site-doc` (micro-api guide) rather than this repo.

#947 remains open as the structural answer — every defect fixed here is a symptom of the hand-rolled `http.ServerResponse` mock, and these are the contained corrections for users on 4.x today, not permanent structure.
