### PR TITLE
fix(adapter): request fidelity on Workers; test Worker scaffolds on workerd

### DIFF
--- a/.changeset/edge-request-fidelity.md
+++ b/.changeset/edge-request-fidelity.md
@@ -1,0 +1,47 @@
+---
+"@expressots/adapter-express": minor
+"@expressots/cli": minor
+---
+
+Request fidelity on Cloudflare Workers, and Worker tests that run on workerd.
+
+**Binary and multipart bodies survive intact (#949).** The adapter read every
+body with `request.text()`, UTF-8 decoding arbitrary bytes — any invalid
+sequence became `U+FFFD` and the original was unrecoverable, silently. File
+uploads were impossible. Bodies are now read as bytes and only decoded when the
+content type is textual; anything else reaches `req.body` as a `Buffer`.
+`multipart/form-data` is parsed with the runtime's native `FormData`, with file
+parts exposed as `{ filename, contentType, size, data }`.
+
+**Duplicate and bracketed keys match Node (#949).** Query strings and
+urlencoded bodies now go through `qs`, the parser
+`express.urlencoded({ extended: true })` uses. Previously `?tag=a&tag=b` gave
+`{ tag: "b" }` on Workers and `{ tag: ["a","b"] }` on Node, so the same handler
+returned different data depending on where it was deployed. `qs` is already in
+the Worker bundle via Express, so this costs no bundle size.
+
+**Request bodies are capped (#949).** Bodies over 1 MiB are rejected with
+**413**, checked against `content-length` before reading. A Workers isolate has
+128 MB of memory and Cloudflare accepts bodies up to 100 MB, so an unbounded
+read was an availability hazard. Configure with
+`cloudflareAdapter(app, { maxBodySize })`; `0` disables it.
+
+**Cloudflare scaffolds test on workerd, not Node (#952).** The target now
+generates Vitest with `@cloudflare/vitest-pool-workers` instead of Jest, plus a
+`vitest.config.mts` pointed at `wrangler.toml`, and specs that drive the Worker
+through `SELF.fetch()`. Node-hosted tests were wrong in both directions:
+`undici` omits `content-length`, so Express body middleware short-circuited and
+a Worker that failed every request in production tested green; and `undici`
+rejects a 204 response body that workerd accepts, so a correct endpoint failed
+its own suite. The generated `tsconfig.json` moves to
+`module: esnext` / `moduleResolution: bundler`, which a Workers project wants
+anyway and which Node10 resolution could not provide.
+
+**CLI: `expressots new` no longer crashes in a narrow terminal (#955).**
+`centerText` passed a negative count to `" ".repeat()`, throwing a `RangeError`
+_after_ the scaffold had completed and reported success — leaving a working
+project alongside a stack trace and a non-zero exit code.
+
+**Build: `turbo run build test` no longer races (#956).** The `test` task
+declared only `^build` (upstream packages), so `@expressots/cli`'s tests could
+spawn `bin/cli.js` while its own build was deleting that directory.

--- a/packages/adapter-express/package.json
+++ b/packages/adapter-express/package.json
@@ -84,6 +84,7 @@
     "@expressots/core": "workspace:*",
     "@expressots/shared": "workspace:*",
     "express": "^5.1.0",
+    "qs": "^6.14.0",
     "reflect-metadata": "0.2.2"
   },
   "peerDependencies": {
@@ -111,7 +112,8 @@
     "prettier": "^3.9.6",
     "ts-jest": "29.4.12",
     "ts-node": "^10.9.2",
-    "typescript": "5.5.3"
+    "typescript": "5.5.3",
+    "@types/qs": "^6.14.0"
   },
   "overrides": {
     "js-yaml": "4.2.0",

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.spec.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.spec.ts
@@ -119,24 +119,24 @@ describe("cloudflareAdapter request bodies", () => {
     expect(await response.json()).toEqual({ error: "Not Found" });
   }, 1000);
 
-  it.each([
-    ["text/plain", "plain text"],
-    ["application/octet-stream", "raw-payload"],
-  ])("keeps %s payloads as text", async (contentType, requestBody) => {
-    const worker = createBodyEchoWorker();
-    const response = await worker.fetch(
-      new Request("https://worker.example/echo", {
-        method: "POST",
-        headers: { "content-type": contentType },
-        body: requestBody,
-      }),
-      {},
-      context,
-    );
+  it.each([["text/plain", "plain text"]])(
+    "keeps %s payloads as text",
+    async (contentType, requestBody) => {
+      const worker = createBodyEchoWorker();
+      const response = await worker.fetch(
+        new Request("https://worker.example/echo", {
+          method: "POST",
+          headers: { "content-type": contentType },
+          body: requestBody,
+        }),
+        {},
+        context,
+      );
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ body: requestBody });
-  });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ body: requestBody });
+    },
+  );
 
   it("parses URL-encoded payloads into a key/value object", async () => {
     const worker = createBodyEchoWorker();
@@ -298,5 +298,156 @@ describe("micro() finalize outside listen()", () => {
 
     expect(response.status).toBe(418);
     expect(await response.json()).toEqual({ handled: true });
+  });
+});
+
+describe("cloudflareAdapter request fidelity", () => {
+  function echoWorker(config?: Parameters<typeof cloudflareAdapter>[1]): CloudflareHandler {
+    const app = micro({ showBanner: false, studio: { enabled: false } });
+    app.post("/echo", (request) => {
+      const body = request.body as unknown;
+      if (Buffer.isBuffer(body)) {
+        return { kind: "buffer", bytes: Array.from(body) };
+      }
+      return { kind: typeof body, body: body ?? null };
+    });
+    app.get("/query", (request) => ({ query: request.query }));
+    return cloudflareAdapter(app, config);
+  }
+
+  it("round-trips binary bodies byte for byte", async () => {
+    // 0xFF/0xFE/0xC8 are invalid UTF-8. text() would replace each with U+FFFD
+    // and lose the original irrecoverably.
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe, 0xc8]);
+    const worker = echoWorker();
+
+    const response = await worker.fetch(
+      new Request("https://worker.example/echo", {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: bytes,
+      }),
+      {},
+      context,
+    );
+
+    expect(await response.json()).toEqual({
+      kind: "buffer",
+      bytes: [0x00, 0x01, 0x02, 0xff, 0xfe, 0xc8],
+    });
+  });
+
+  it("parses multipart/form-data without corrupting file bytes", async () => {
+    const form = new FormData();
+    form.append("name", "widget");
+    form.append(
+      "file",
+      new Blob([new Uint8Array([0xff, 0x00, 0xc8])], { type: "application/octet-stream" }),
+      "raw.bin",
+    );
+
+    const app = micro({ showBanner: false, studio: { enabled: false } });
+    app.post("/upload", (request) => {
+      const body = request.body as Record<string, unknown>;
+      const file = body.file as { filename: string; size: number; data: Buffer };
+      return {
+        name: body.name,
+        filename: file.filename,
+        size: file.size,
+        bytes: Array.from(file.data),
+      };
+    });
+
+    const worker = cloudflareAdapter(app);
+    const response = await worker.fetch(
+      new Request("https://worker.example/upload", { method: "POST", body: form }),
+      {},
+      context,
+    );
+
+    expect(await response.json()).toEqual({
+      name: "widget",
+      filename: "raw.bin",
+      size: 3,
+      bytes: [0xff, 0x00, 0xc8],
+    });
+  });
+
+  it.each([
+    ["tag=a&tag=b", { tag: ["a", "b"] }],
+    ["n[]=x&n[]=y", { n: ["x", "y"] }],
+    ["u[name]=jo", { u: { name: "jo" } }],
+  ])("parses urlencoded %s the way express.urlencoded does", async (raw, expected) => {
+    const worker = echoWorker();
+    const response = await worker.fetch(
+      new Request("https://worker.example/echo", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: raw,
+      }),
+      {},
+      context,
+    );
+
+    expect(await response.json()).toEqual({ kind: "object", body: expected });
+  });
+
+  it("keeps duplicate query keys instead of letting the last one win", async () => {
+    const worker = echoWorker();
+    const response = await worker.fetch(
+      new Request("https://worker.example/query?tag=a&tag=b&u[name]=jo"),
+      {},
+      context,
+    );
+
+    expect(await response.json()).toEqual({
+      query: { tag: ["a", "b"], u: { name: "jo" } },
+    });
+  });
+
+  it("rejects a body larger than maxBodySize with 413 from content-length", async () => {
+    const worker = echoWorker({ maxBodySize: 16 });
+    const response = await worker.fetch(
+      new Request("https://worker.example/echo", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "x".repeat(64),
+      }),
+      {},
+      context,
+    );
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: "Payload Too Large", limit: 16 });
+  });
+
+  it("allows a body at the limit", async () => {
+    const worker = echoWorker({ maxBodySize: 16 });
+    const response = await worker.fetch(
+      new Request("https://worker.example/echo", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "x".repeat(16),
+      }),
+      {},
+      context,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("treats maxBodySize: 0 as unlimited", async () => {
+    const worker = echoWorker({ maxBodySize: 0 });
+    const response = await worker.fetch(
+      new Request("https://worker.example/echo", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "x".repeat(4096),
+      }),
+      {},
+      context,
+    );
+
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/cloudflare.adapter.ts
@@ -6,12 +6,73 @@
  * or uses a fetch-based approach.
  */
 
+import qs from "qs";
 import {
+  DEFAULT_MAX_BODY_BYTES,
+  isTextualContentType,
   NULL_BODY_STATUSES,
   prepareServerlessApp,
   resolveExpressApp,
   ServerlessApp,
 } from "./serverless-app.js";
+
+function jsonResponse(status: number, payload: unknown): globalThis.Response {
+  return new globalThis.Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function badRequest(): globalThis.Response {
+  return jsonResponse(400, { error: "Bad Request" });
+}
+
+function payloadTooLarge(limit: number): globalThis.Response {
+  return jsonResponse(413, { error: "Payload Too Large", limit });
+}
+
+/**
+ * Turn a parsed `FormData` into a plain object.
+ *
+ * Repeated field names become arrays, matching how `qs` treats repeated
+ * urlencoded keys. File parts keep their bytes as a Buffer rather than being
+ * stringified.
+ */
+async function formDataToObject(form: globalThis.FormData): Promise<Record<string, unknown>> {
+  const result: Record<string, unknown> = {};
+
+  const entries: Array<[string, globalThis.FormDataEntryValue]> = [];
+  form.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+
+  for (const [key, value] of entries) {
+    let parsed: unknown;
+
+    if (typeof value === "string") {
+      parsed = value;
+    } else {
+      const file = value as globalThis.File;
+      parsed = {
+        filename: file.name,
+        contentType: file.type,
+        size: file.size,
+        data: Buffer.from(await file.arrayBuffer()),
+      };
+    }
+
+    const existing = result[key];
+    if (existing === undefined) {
+      result[key] = parsed;
+    } else if (Array.isArray(existing)) {
+      existing.push(parsed);
+    } else {
+      result[key] = [existing, parsed];
+    }
+  }
+
+  return result;
+}
 
 /**
  * Cloudflare Workers Environment bindings
@@ -45,6 +106,26 @@ export type CloudflareHandler = {
 export interface CloudflareAdapterConfig {
   /** Enable debug logging */
   debug?: boolean;
+  /**
+   * Maximum buffered request body in bytes. Bodies whose `content-length`
+   * exceeds this are rejected with 413 before being read. Defaults to 1 MiB.
+   * Set to `0` to disable the limit (not recommended: a Workers isolate has
+   * 128 MB of memory and Cloudflare accepts bodies up to 100 MB).
+   */
+  maxBodySize?: number;
+}
+
+/**
+ * A file received in a `multipart/form-data` body.
+ *
+ * Multipart is parsed with the runtime's native `FormData`, so bytes survive
+ * intact — `multer` and friends cannot run on this target.
+ */
+export interface CloudflareUploadedFile {
+  filename: string;
+  contentType: string;
+  size: number;
+  data: Buffer;
 }
 
 /**
@@ -88,6 +169,7 @@ export function cloudflareAdapter(
   prepareServerlessApp(expressApp, "cloudflareAdapter");
 
   const debug = config?.debug ?? false;
+  const maxBodySize = config?.maxBodySize ?? DEFAULT_MAX_BODY_BYTES;
 
   return {
     async fetch(
@@ -108,37 +190,71 @@ export function cloudflareAdapter(
       // Parse body if present
       let body: unknown;
       if (request.method !== "GET" && request.method !== "HEAD") {
-        const requestBody = await request.text();
-        if (requestBody) {
-          const contentType = request.headers
-            .get("content-type")
-            ?.split(";", 1)[0]
-            .trim()
-            .toLowerCase();
-          const isJson = contentType === "application/json" || contentType?.endsWith("+json");
+        const contentType = request.headers
+          .get("content-type")
+          ?.split(";", 1)[0]
+          .trim()
+          .toLowerCase();
 
-          if (isJson) {
-            try {
-              body = JSON.parse(requestBody);
-            } catch {
-              return new globalThis.Response(JSON.stringify({ error: "Bad Request" }), {
-                status: 400,
-                headers: { "content-type": "application/json" },
-              });
+        // Reject oversized bodies from the declared length, before reading a
+        // single byte. Bodies sent without content-length are still capped
+        // below, but only after buffering — streaming is #947.
+        const declaredLength = Number(request.headers.get("content-length"));
+        if (maxBodySize > 0 && Number.isFinite(declaredLength) && declaredLength > maxBodySize) {
+          return payloadTooLarge(maxBodySize);
+        }
+
+        if (contentType === "multipart/form-data") {
+          // The runtime's own multipart parser. Hand-decoding would repeat
+          // the UTF-8 corruption this whole branch exists to avoid.
+          try {
+            const form = await request.formData();
+            body = await formDataToObject(form);
+          } catch {
+            return badRequest();
+          }
+        } else {
+          // Read as bytes first so the size cap applies even without a
+          // content-length header, and so non-text payloads survive intact.
+          const raw = Buffer.from(await request.arrayBuffer());
+
+          if (maxBodySize > 0 && raw.byteLength > maxBodySize) {
+            return payloadTooLarge(maxBodySize);
+          }
+
+          if (raw.byteLength > 0) {
+            if (!isTextualContentType(contentType)) {
+              // Binary stays binary. `request.text()` would UTF-8 decode it
+              // and replace every invalid sequence with U+FFFD, silently and
+              // irrecoverably corrupting uploads.
+              body = raw;
+            } else {
+              const requestBody = raw.toString("utf8");
+              const isJson = contentType === "application/json" || contentType?.endsWith("+json");
+
+              if (isJson) {
+                try {
+                  body = JSON.parse(requestBody);
+                } catch {
+                  return badRequest();
+                }
+              } else if (contentType === "application/x-www-form-urlencoded") {
+                // qs, not URLSearchParams: it is what express.urlencoded({
+                // extended: true }) uses, so `a=1&a=2`, `n[]=x` and
+                // `u[name]=jo` produce the same shapes they do on Node.
+                body = qs.parse(requestBody);
+              } else {
+                body = requestBody;
+              }
             }
-          } else if (contentType === "application/x-www-form-urlencoded") {
-            body = Object.fromEntries(new URLSearchParams(requestBody));
-          } else {
-            body = requestBody;
           }
         }
       }
 
-      // Build query parameters
-      const query: Record<string, string> = {};
-      url.searchParams.forEach((value, key) => {
-        query[key] = value;
-      });
+      // Build query parameters with the same parser Express uses, so
+      // `?tag=a&tag=b` is an array here as well rather than the last value
+      // winning.
+      const query = qs.parse(url.search.replace(/^\?/, ""));
 
       // Build headers
       const headers: Record<string, string> = {};

--- a/packages/adapter-express/src/adapter-express/micro-api/serverless/serverless-app.ts
+++ b/packages/adapter-express/src/adapter-express/micro-api/serverless/serverless-app.ts
@@ -14,6 +14,41 @@ export type ServerlessApp =
   { getExpressApp?: () => Application } | { getApp?: () => Application } | Application;
 
 /**
+ * Default ceiling on a buffered request body, matching the spirit of
+ * `express.json()`'s 100 KB default but sized for API payloads.
+ *
+ * Workers isolates get 128 MB of memory and Cloudflare accepts bodies up to
+ * 100 MB, so an unbounded read is an availability hazard: one large upload
+ * can OOM the isolate. Configurable per adapter.
+ */
+export const DEFAULT_MAX_BODY_BYTES = 1_048_576;
+
+/**
+ * Content types whose bodies are text and can be UTF-8 decoded safely.
+ * Everything else is treated as binary and kept as a Buffer — decoding
+ * arbitrary bytes as UTF-8 replaces every invalid sequence with U+FFFD and
+ * loses the original irrecoverably, which made file uploads impossible.
+ */
+export function isTextualContentType(contentType: string | undefined): boolean {
+  if (!contentType) {
+    // No content type means we cannot know. Text is the safer default
+    // here: it preserves the historical behaviour for plain payloads.
+    return true;
+  }
+
+  return (
+    contentType.startsWith("text/") ||
+    contentType === "application/json" ||
+    contentType.endsWith("+json") ||
+    contentType === "application/x-www-form-urlencoded" ||
+    contentType === "application/xml" ||
+    contentType.endsWith("+xml") ||
+    contentType === "application/javascript" ||
+    contentType === "application/graphql"
+  );
+}
+
+/**
  * Statuses whose responses must not carry a body. Passing even an empty
  * Buffer for these throws `TypeError: Invalid response status code` under
  * Node/undici, while workerd tolerates it — so a 204 endpoint would pass in

--- a/packages/cli/src/new/cloudflare-target.ts
+++ b/packages/cli/src/new/cloudflare-target.ts
@@ -11,6 +11,18 @@ export const CLOUDFLARE_COMPATIBILITY_DATE = "2026-07-29";
 export const WRANGLER_VERSION = "^4.115.0";
 
 /**
+ * Worker tests run inside workerd via Miniflare, not under Node.
+ *
+ * Node-hosted tests are wrong in both directions here: undici omits
+ * `content-length`, so body-parser short-circuits and a Worker that 500s on
+ * every request goes green; and undici rejects a 204 `Response` body that
+ * workerd accepts, so a correct endpoint fails its own suite. The pool's
+ * vitest peer range is narrow, so these three move together.
+ */
+export const VITEST_VERSION = "^4.1.0";
+export const VITEST_POOL_WORKERS_VERSION = "^0.20.1";
+
+/**
  * Files the micro template ships for the Node.js workflow that have no
  * meaning on Workers. Also used to prune the tsconfig `include` array, so
  * the two never drift apart.
@@ -20,9 +32,18 @@ const NODE_ONLY_SCAFFOLD_PATHS = [
 	"examples",
 	"expressots.config.ts",
 	"tsconfig.build.json",
+	// The Worker suite runs on workerd through Vitest, so the Jest config
+	// would only serve to run tests against the wrong runtime.
+	"jest.config.ts",
 ] as const;
 
 const WORKER_TYPES_FILE = "worker-configuration.d.ts";
+
+/**
+ * Supplies the `cloudflare:test` module declarations used by the spec. The
+ * declarations live behind the `/types` subpath, not the package root.
+ */
+const WORKER_TEST_TYPES = "@cloudflare/vitest-pool-workers/types";
 
 export interface CloudflareTargetOptions {
 	targetDir: string;
@@ -47,21 +68,16 @@ app.get("/health", () => ({
 export default cloudflareAdapter(app.getApp());
 `;
 
-const CLOUDFLARE_TEST_SOURCE = `import worker from "../src/api";
+const CLOUDFLARE_TEST_SOURCE = `import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
 
-const env = {};
-const ctx = {
-    waitUntil: (_promise: Promise<unknown>) => undefined,
-    passThroughOnException: () => undefined,
-};
-
+// SELF.fetch() dispatches through the real Worker inside workerd, so these
+// assertions exercise the runtime the code actually ships to. Importing the
+// handler and calling it under Node would test undici instead, which both
+// hides real failures and invents fake ones.
 describe("Cloudflare Worker", () => {
     it("returns the welcome message on GET /", async () => {
-        const response = await worker.fetch(
-            new Request("http://localhost/"),
-            env,
-            ctx,
-        );
+        const response = await SELF.fetch("https://example.com/");
 
         expect(response.status).toBe(200);
         expect(await response.text()).toBe(
@@ -70,11 +86,7 @@ describe("Cloudflare Worker", () => {
     });
 
     it("returns health details on GET /health", async () => {
-        const response = await worker.fetch(
-            new Request("http://localhost/health"),
-            env,
-            ctx,
-        );
+        const response = await SELF.fetch("https://example.com/health");
 
         expect(response.status).toBe(200);
         expect(await response.json()).toEqual({
@@ -82,6 +94,34 @@ describe("Cloudflare Worker", () => {
             timestamp: expect.any(String),
         });
     });
+
+    it("parses a JSON body sent with content-length", async () => {
+        // Node's undici omits content-length, which makes body-parser
+        // short-circuit and hides runtime failures. workerd sends it.
+        const response = await SELF.fetch("https://example.com/", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ ping: true }),
+        });
+
+        expect(response.status).toBe(404);
+        expect(response.headers.get("content-type")).toContain("application/json");
+    });
+});
+`;
+
+const CLOUDFLARE_VITEST_CONFIG = `import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+// cloudflareTest() is a Vite plugin as of @cloudflare/vitest-pool-workers
+// 0.20 / Vitest 4; earlier versions used defineWorkersConfig from the
+// "/config" subpath, which no longer exists.
+export default defineConfig({
+    plugins: [
+        cloudflareTest({
+            wrangler: { configPath: "./wrangler.toml" },
+        }),
+    ],
 });
 `;
 
@@ -130,14 +170,20 @@ functional style. No DI container. Runs on workerd, not Node.js.
   body before returning it.
 - **No \`.env\` files.** Configuration comes from \`wrangler.toml\` vars and
   secrets, reachable through the bindings on the request context.
-- Request bodies are parsed by content type: JSON and \`application/*+json\`
-  and URL-encoded forms arrive as objects; text and bodies with no content
-  type arrive as strings.
+- Request bodies are parsed by content type. JSON, \`application/*+json\` and
+  URL-encoded forms arrive as objects (with \`qs\` semantics, so \`a=1&a=2\`
+  and \`u[name]=jo\` behave as they do on Node); text arrives as a string;
+  anything else — images, \`application/octet-stream\` — arrives as a
+  \`Buffer\` with its bytes intact. \`multipart/form-data\` is parsed with the
+  runtime's own \`FormData\`, with file parts as
+  \`{ filename, contentType, size, data }\`.
+- Bodies over 1 MiB are rejected with 413. Change it with
+  \`cloudflareAdapter(app, { maxBodySize })\`.
 
 ## Commands
 
 - \`${devCommand}\`: \`wrangler dev\` on the local Workers runtime.
-- \`${testCommand}\`: Jest against the exported \`fetch\` handler, no HTTP port.
+- \`${testCommand}\`: Vitest inside workerd via \`@cloudflare/vitest-pool-workers\`.
 - \`${buildCommand}\`: \`wrangler deploy --dry-run\` to validate the bundle.
 - \`${deployCommand}\`: deploy to Cloudflare.
 - \`${typesCommand}\`: regenerate \`${WORKER_TYPES_FILE}\` after editing
@@ -223,7 +269,8 @@ Wrangler owns the development, build, and deployment workflow instead.
 
 \`\`\`text
 src/api.ts                 Worker entrypoint and micro routes
-test/api.spec.ts           Jest tests that call the Worker fetch handler
+test/api.spec.ts           Vitest tests that run inside workerd
+vitest.config.mts          Test runner config, pointed at wrangler.toml
 wrangler.toml              Cloudflare Worker configuration
 worker-configuration.d.ts  Generated binding types (after running the types script)
 \`\`\`
@@ -235,8 +282,21 @@ app.get("/users", () => ({ users: [] }));
 app.post("/users", (req) => ({ received: req.body }));
 \`\`\`
 
-Return values are serialized by the micro API. The adapter supports JSON,
-\`application/*+json\`, URL-encoded forms, and text request bodies.
+Return values are serialized by the micro API.
+
+Request bodies are parsed by content type:
+
+| Content-Type | \`req.body\` |
+| --- | --- |
+| \`application/json\`, \`application/*+json\` | Parsed object. Malformed JSON returns 400 without reaching your handler. |
+| \`application/x-www-form-urlencoded\` | Object, parsed with \`qs\` — same shapes as \`express.urlencoded({ extended: true })\`. |
+| \`multipart/form-data\` | Object; file parts become \`{ filename, contentType, size, data }\` with \`data\` a \`Buffer\`. |
+| \`text/*\`, or no content type | The raw string. |
+| Anything else | A \`Buffer\` with the bytes intact. |
+
+Bodies larger than 1 MiB are rejected with 413. Adjust with
+\`cloudflareAdapter(app, { maxBodySize: 5 * 1024 * 1024 })\`, or pass \`0\` to
+disable the limit.
 
 ## Test
 
@@ -244,8 +304,15 @@ Return values are serialized by the micro API. The adapter supports JSON,
 ${testCommand}
 \`\`\`
 
-The generated tests call the exported Worker handler directly without opening
-a Node.js HTTP port.
+Tests run **inside workerd**, not Node, using
+[\`@cloudflare/vitest-pool-workers\`](https://developers.cloudflare.com/workers/testing/vitest-integration/).
+\`SELF.fetch()\` dispatches through the real Worker, so the suite exercises the
+runtime this project deploys to.
+
+This matters: under Node, \`undici\` omits \`content-length\`, which makes
+Express body middleware short-circuit and hides failures that only appear in
+production — and it rejects a 204 response body that workerd accepts, failing
+correct endpoints. Testing on the wrong runtime is wrong in both directions.
 
 ## Generate binding types
 
@@ -372,13 +439,46 @@ function configureWorkerTypes(targetDir: string): void {
 		.map((entry) => JSON.stringify(entry))
 		.join(", ")}]`;
 
-	fs.writeFileSync(
-		tsconfigPath,
-		tsconfig.replace(includePattern, (_full, prefix: string) => {
-			return `${prefix}${serializedInclude}`;
-		}),
-		"utf8",
-	);
+	let next = tsconfig.replace(includePattern, (_full, prefix: string) => {
+		return `${prefix}${serializedInclude}`;
+	});
+
+	// The template targets CommonJS on Node. A Worker is an ES module bundled
+	// by Wrangler, and `moduleResolution: "node"` (Node10) cannot read the
+	// `exports` maps that `@cloudflare/vitest-pool-workers` and other modern
+	// packages publish — which makes `cloudflare:test` unresolvable and the
+	// generated spec fail to typecheck.
+	next = next
+		.replace(/("module"\s*:\s*)"commonjs"/i, '$1"esnext"')
+		.replace(/("moduleResolution"\s*:\s*)"node"/i, '$1"bundler"');
+
+	// Jest's types go with Jest. The Vitest pool ships the `cloudflare:test`
+	// module declarations, so without this the generated spec does not
+	// typecheck.
+	const typesPattern = /("types"\s*:\s*)(\[[\s\S]*?\])/;
+	const typesMatch = next.match(typesPattern);
+	if (typesMatch) {
+		let currentTypes: Array<string> = [];
+		try {
+			currentTypes = JSON.parse(typesMatch[2]) as Array<string>;
+		} catch {
+			currentTypes = [];
+		}
+
+		const nextTypes = currentTypes.filter((entry) => entry !== "jest");
+		if (!nextTypes.includes(WORKER_TEST_TYPES)) {
+			nextTypes.push(WORKER_TEST_TYPES);
+		}
+
+		const serializedTypes = `[${nextTypes
+			.map((entry) => JSON.stringify(entry))
+			.join(", ")}]`;
+		next = next.replace(typesPattern, (_full, prefix: string) => {
+			return `${prefix}${serializedTypes}`;
+		});
+	}
+
+	fs.writeFileSync(tsconfigPath, next, "utf8");
 }
 
 function removeNodeScaffoldArtifacts(targetDir: string): void {
@@ -449,6 +549,9 @@ export function applyCloudflareTarget({
 		dev: "wrangler dev",
 		deploy: "wrangler deploy",
 		types: "wrangler types",
+		test: "vitest run",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage",
 	};
 	delete pkg.scripts.prod;
 	delete pkg.scripts.studio;
@@ -460,6 +563,8 @@ export function applyCloudflareTarget({
 
 	pkg.devDependencies = {
 		...pkg.devDependencies,
+		"@cloudflare/vitest-pool-workers": VITEST_POOL_WORKERS_VERSION,
+		vitest: VITEST_VERSION,
 		wrangler: WRANGLER_VERSION,
 	};
 	delete pkg.devDependencies["@expressots/cli"];
@@ -467,9 +572,22 @@ export function applyCloudflareTarget({
 	delete pkg.devDependencies["@expressots/studio-agent"];
 	delete pkg.devDependencies.tsx;
 
+	// Jest runs under Node, which is not the runtime this project deploys to.
+	// The Worker suite runs inside workerd instead, so Jest and its transform
+	// would be dead weight that also invites tests written against the wrong
+	// runtime.
+	delete pkg.devDependencies.jest;
+	delete pkg.devDependencies["ts-jest"];
+	delete pkg.devDependencies["@types/jest"];
+
 	fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 4)}\n`, "utf8");
 	fs.writeFileSync(apiPath, CLOUDFLARE_API_SOURCE, "utf8");
 	fs.writeFileSync(testPath, CLOUDFLARE_TEST_SOURCE, "utf8");
+	fs.writeFileSync(
+		path.join(targetDir, "vitest.config.mts"),
+		CLOUDFLARE_VITEST_CONFIG,
+		"utf8",
+	);
 	fs.writeFileSync(
 		wranglerPath,
 		[

--- a/packages/cli/src/utils/center-text.ts
+++ b/packages/cli/src/utils/center-text.ts
@@ -1,9 +1,24 @@
-function centerText(text: string): string {
-	const terminalWidth = process.stdout.columns;
-	const padding = Math.floor((terminalWidth - text.length) / 2);
-	const centeredText = " ".repeat(padding) + text;
+/**
+ * Width used when stdout is not a TTY (pipes, CI logs, some editor terminals),
+ * where `process.stdout.columns` is `undefined`. Matches the fallback
+ * `commandOptions` already uses for yargs wrapping.
+ */
+const FALLBACK_WIDTH = 120;
 
-	return centeredText;
+function centerText(text: string): string {
+	const terminalWidth =
+		typeof process.stdout.columns === "number" && process.stdout.columns > 0
+			? process.stdout.columns
+			: FALLBACK_WIDTH;
+
+	// `" ".repeat(n)` throws RangeError for negative n. That was reachable:
+	// a terminal narrower than the text crashed the CLI *after* it had already
+	// reported the scaffold as successful, and exited non-zero — which breaks
+	// any script checking the exit status. Text wider than the terminal simply
+	// cannot be centred, so return it unpadded.
+	const padding = Math.max(0, Math.floor((terminalWidth - text.length) / 2));
+
+	return " ".repeat(padding) + text;
 }
 
 export { centerText };

--- a/packages/cli/test/new/cloudflare-scaffold.spec.ts
+++ b/packages/cli/test/new/cloudflare-scaffold.spec.ts
@@ -97,11 +97,13 @@ describe("Cloudflare target validation", () => {
 			path.join(projectDir, "test", "api.spec.ts"),
 			"utf8",
 		);
-		expect(workerTest).toContain('import worker from "../src/api";');
-		expect(workerTest).toContain(
-			'new Request("http://localhost/")',
-		);
-		expect(workerTest).toContain('new Request("http://localhost/health")');
+		// The suite must run inside workerd, not Node: undici hides the
+		// body-parser failures and invents a 204 failure of its own.
+		expect(workerTest).toContain('import { SELF } from "cloudflare:test";');
+		expect(workerTest).toContain('from "vitest"');
+		expect(workerTest).toContain('SELF.fetch("https://example.com/")');
+		expect(workerTest).toContain("content-length");
+		expect(workerTest).not.toContain('import worker from "../src/api"');
 		expect(workerTest).not.toContain("micro(");
 		expect(workerTest).not.toContain(".listen(");
 		expect(workerTest).not.toContain("getHttpServer");
@@ -142,6 +144,28 @@ describe("Cloudflare target validation", () => {
 		expect(pkg.scripts["example:circuit-breaker"]).toBeUndefined();
 		expect(pkg.devDependencies["@expressots/cli"]).toBeUndefined();
 		expect(pkg.devDependencies.tsx).toBeUndefined();
+
+		// Worker tests run on workerd via Vitest, not on Node via Jest.
+		expect(pkg.scripts.test).toBe("vitest run");
+		expect(pkg.devDependencies.vitest).toBeDefined();
+		expect(
+			pkg.devDependencies["@cloudflare/vitest-pool-workers"],
+		).toBeDefined();
+		expect(pkg.devDependencies.jest).toBeUndefined();
+		expect(pkg.devDependencies["ts-jest"]).toBeUndefined();
+		expect(pkg.devDependencies["@types/jest"]).toBeUndefined();
+		expect(fs.existsSync(path.join(projectDir, "jest.config.ts"))).toBe(
+			false,
+		);
+
+		const vitestConfig = fs.readFileSync(
+			// .mts, because the pool is ESM-only and the project is not
+			// "type": "module" — a .ts config would be loaded as CJS.
+			path.join(projectDir, "vitest.config.mts"),
+			"utf8",
+		);
+		expect(vitestConfig).toContain("cloudflareTest");
+		expect(vitestConfig).toContain("./wrangler.toml");
 		for (const nodeOnlyPath of [
 			".env.example",
 			"examples",
@@ -171,6 +195,12 @@ describe("Cloudflare target validation", () => {
 		);
 		expect(tsconfig).toContain('"worker-configuration.d.ts"');
 		expect(tsconfig).not.toContain('"expressots.config.ts"');
+		// Node10 resolution cannot read the pool's exports subpath, so
+		// `cloudflare:test` would not typecheck.
+		expect(tsconfig).toContain('"moduleResolution": "bundler"');
+		expect(tsconfig).toContain('"module": "esnext"');
+		expect(tsconfig).toContain('"@cloudflare/vitest-pool-workers/types"');
+		expect(tsconfig).not.toContain('"jest"');
 		expect(`${result.stdout}\n${result.stderr}`).toContain(
 			"$ pnpm run dev",
 		);

--- a/packages/cli/test/new/cloudflare-target.spec.ts
+++ b/packages/cli/test/new/cloudflare-target.spec.ts
@@ -149,11 +149,13 @@ describe("applyCloudflareTarget", () => {
 			path.join(targetDir, "test", "api.spec.ts"),
 			"utf8",
 		);
-		expect(workerTest).toContain('import worker from "../src/api";');
-		expect(workerTest).toContain(
-			'new Request("http://localhost/")',
-		);
-		expect(workerTest).toContain('new Request("http://localhost/health")');
+		// The suite must run inside workerd, not Node: undici hides the
+		// body-parser failures and invents a 204 failure of its own.
+		expect(workerTest).toContain('import { SELF } from "cloudflare:test";');
+		expect(workerTest).toContain('from "vitest"');
+		expect(workerTest).toContain('SELF.fetch("https://example.com/")');
+		expect(workerTest).toContain("content-length");
+		expect(workerTest).not.toContain('import worker from "../src/api"');
 		expect(workerTest).not.toContain("micro(");
 		expect(workerTest).not.toContain(".listen(");
 		expect(workerTest).not.toContain("getHttpServer");
@@ -166,7 +168,8 @@ describe("applyCloudflareTarget", () => {
 			dev: "wrangler dev",
 			deploy: "wrangler deploy",
 			types: "wrangler types",
-			test: "jest",
+			// Vitest on workerd, not Jest on Node.
+			test: "vitest run",
 		});
 		expect(pkg.scripts.prod).toBeUndefined();
 		expect(pkg.scripts.studio).toBeUndefined();

--- a/packages/cli/test/utils/center-text.spec.ts
+++ b/packages/cli/test/utils/center-text.spec.ts
@@ -1,0 +1,61 @@
+import { centerText } from "../../src/utils/center-text";
+
+describe("centerText", () => {
+	const originalColumns = Object.getOwnPropertyDescriptor(
+		process.stdout,
+		"columns",
+	);
+
+	const setColumns = (value: number | undefined): void => {
+		Object.defineProperty(process.stdout, "columns", {
+			value,
+			configurable: true,
+			writable: true,
+		});
+	};
+
+	afterEach(() => {
+		if (originalColumns) {
+			Object.defineProperty(process.stdout, "columns", originalColumns);
+		}
+	});
+
+	it("centres text in a normal terminal", () => {
+		setColumns(80);
+
+		const result = centerText("hello");
+
+		// (80 - 5) / 2 floored = 37
+		expect(result).toBe(`${" ".repeat(37)}hello`);
+	});
+
+	it("does not throw when the terminal is narrower than the text", () => {
+		setColumns(10);
+
+		// This threw `RangeError: Invalid count value: -N` and took the whole
+		// CLI down after a successful scaffold.
+		expect(() => centerText("a text far wider than ten columns")).not.toThrow();
+		expect(centerText("a text far wider than ten columns")).toBe(
+			"a text far wider than ten columns",
+		);
+	});
+
+	it("does not throw when the text exactly fills the terminal", () => {
+		setColumns(5);
+
+		expect(centerText("hello")).toBe("hello");
+	});
+
+	it("falls back to a fixed width when stdout is not a TTY", () => {
+		setColumns(undefined);
+
+		// (120 - 5) / 2 floored = 57
+		expect(centerText("hello")).toBe(`${" ".repeat(57)}hello`);
+	});
+
+	it("falls back to a fixed width when columns is zero", () => {
+		setColumns(0);
+
+		expect(centerText("hello")).toBe(`${" ".repeat(57)}hello`);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      qs:
+        specifier: ^6.14.0
+        version: 6.15.3
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
@@ -237,6 +240,9 @@ importers:
       '@types/node':
         specifier: 20.14.10
         version: 20.14.10
+      '@types/qs':
+        specifier: ^6.14.0
+        version: 6.15.1
       '@typescript-eslint/eslint-plugin':
         specifier: 7.16.1
         version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "outputs": ["lib/**", "dist/**", "bin/**"]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "build"]
     },
     "lint": {},
     "format": {}


### PR DESCRIPTION
:black_heart:

## PR Type
- [x] Bugfix
- [x] Feature
- [x] Build related changes
- [x] Test

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What was changed?

The remaining tractable follow-ups. All verified against a live `workerd` instance.

Closes #949
Closes #952
Closes #955
Closes #956

### #949 — request fidelity

| Input | Before | After |
|---|---|---|
| `application/octet-stream` bytes `00 01 02 FF FE C8` | 6-char string, last 3 bytes replaced by `U+FFFD` | `Buffer` with all 6 bytes intact |
| `multipart/form-data` | Lossy string, unparsed | Native `FormData`; files as `{ filename, contentType, size, data }` |
| `?tag=a&tag=b` | `{ tag: "b" }` | `{ tag: ["a","b"] }` |
| body `u[name]=jo` | `{ "u[name]": "jo" }` | `{ u: { name: "jo" } }` |
| 100 MB body | Buffered unbounded, can OOM the isolate | **413** from `content-length`, before reading |

Bodies are read as bytes and only UTF-8 decoded when the content type is textual. Query strings and urlencoded bodies go through `qs` — the parser `express.urlencoded({ extended: true })` uses — so the same handler returns the same data on Node and on Workers. **`qs` is already in the Worker bundle via Express**, so full parity cost no bundle size; the alternative (`URLSearchParams.getAll()`) would have fixed arrays but left bracket syntax diverging.

`maxBodySize` defaults to 1 MiB and is configurable; `0` disables it.

### #952 — Worker scaffolds test on workerd

The target now generates Vitest + `@cloudflare/vitest-pool-workers` instead of Jest, a `vitest.config.mts` pointed at `wrangler.toml`, and specs driving the Worker through `SELF.fetch()`.

A freshly scaffolded project, with no extra setup:

```
 RUN  v4.1.10
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

…including the `content-length` POST that Jest structurally cannot see. `tsc --noEmit`, `eslint` and `wrangler deploy --dry-run` are all clean on that same scaffold.

Two things this needed that are worth calling out:

- **`vitest.config.mts`, not `.ts`** — the pool is ESM-only and the generated project is not `"type": "module"`, so a `.ts` config is loaded as CJS and fails.
- **`module: esnext` / `moduleResolution: bundler`** in the generated tsconfig. The template's Node10 resolution cannot read the pool's `exports` subpath, so `cloudflare:test` would not typecheck. A Workers project wants bundler resolution regardless.

Note the pool's API changed in 0.20 / Vitest 4: `defineWorkersConfig` from the `/config` subpath is gone, replaced by the `cloudflareTest()` Vite plugin. The generated config uses the current form.

### #955 — CLI crash in a narrow terminal

`centerText` passed a negative count to `" ".repeat()`. It threw *after* the scaffold completed and printed "created successfully", so users got a working project plus a stack trace and a non-zero exit code. Now clamped, with a fixed-width fallback when stdout is not a TTY.

### #956 — turbo build/test race

`test` declared only `^build` (upstream packages), so `@expressots/cli`'s tests could spawn `bin/cli.js` while its own build was running `rm -rf bin`. `turbo run build test lint --force` failed with 37 errors before this change and is green after.

## Other information

**Gates:** adapter-express **411** (+8), cli **553** (+5), core 2812, shared 68, boost-ts 3 — all green, and now green in a single combined `turbo run build test lint` invocation.

Documentation is updated in `expressots/expresso-site-doc`.

**#947 is deliberately not addressed here** — it is the fetch-native RFC that these fixes are symptoms of, and it wants design discussion before code.