### PR TITLE
chore(tooling): add pack:local --link to wire a test app to a local build

### DIFF
--- a/CONTRIBUTING_HOWTO.md
+++ b/CONTRIBUTING_HOWTO.md
@@ -56,10 +56,35 @@ Note: `--package=<tarball> expressots` is required. The CLI ships two binaries
 (`expressots` and `ex`), so `npx <tarball>` alone cannot pick one and fails
 with a confusing "Permission denied" on the tarball path.
 
-### 2. Install the framework from the local tarballs
+### 2. Point the app at the local tarballs
 
-Install all tarballs in **one** command so internal `@expressots/*`
-dependencies resolve from the sibling tarballs instead of the npm registry:
+The one-step way — packs a fresh build and rewires the app in place:
+
+```bash
+pnpm pack:local --link ../my-app
+```
+
+`--link` rewrites the app's `@expressots/*` dependencies to the freshly packed
+tarballs, pins the transitive ones (`@expressots/adapter-express` depends on
+`@expressots/core` _by version_, so without a pin the published copy installs
+alongside the local one and the bundler picks the wrong file), and reinstalls
+with the app's package manager.
+
+The tarball filenames carry a content hash. Package managers cache `file:`
+specifiers by path, so without it a re-link after a rebuild silently reuses the
+previous tarball and you test stale code — which looks exactly like "my fix
+doesn't work".
+
+A freshly scaffolded app has no lockfile, so there is nothing to detect the
+package manager from and `--link` assumes npm. Say which one you want:
+
+```bash
+pnpm pack:local --link ../my-app --pm bun     # npm | pnpm | yarn | bun
+```
+
+Doing it by hand instead is fine — install all tarballs in **one** command so
+internal `@expressots/*` dependencies resolve from the siblings rather than the
+registry:
 
 ```bash
 cd my-app
@@ -74,9 +99,8 @@ npm run dev    # watch mode; or `npm run prod` for the compiled build
 curl http://localhost:3000/api/health
 ```
 
-After editing framework code, repeat `pnpm pack:local` (fast — turbo only
-rebuilds what changed) and re-run the `npm install ...tgz` command in the test
-app to pick up the new tarballs.
+After editing framework code, re-run `pnpm pack:local --link ../my-app` (fast —
+turbo only rebuilds what changed). That repacks and reinstalls in one step.
 
 ### Why tarballs instead of `npm link`?
 

--- a/scripts/pack-local.mjs
+++ b/scripts/pack-local.mjs
@@ -10,14 +10,48 @@
  * Installing all tarballs in one command lets the package manager satisfy
  * internal @expressots/* dependencies (workspace:* is rewritten to the
  * real version by `pnpm pack`) from the sibling tarballs instead of npm.
+ *
+ * Or point an existing project at the freshly packed build in one step:
+ *
+ *   pnpm pack:local --link ../my-test-app
+ *
+ * `--link` rewrites that project's @expressots/* dependencies to the local
+ * tarballs, pins the transitive ones so a published copy cannot sneak back
+ * in, and reinstalls with whichever package manager the project uses.
  */
 import { execSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DEST = path.join(ROOT, ".local-packs");
+
+const args = process.argv.slice(2);
+const linkIndex = args.findIndex((a) => a === "--link" || a.startsWith("--link="));
+let linkTarget = null;
+if (linkIndex !== -1) {
+  const arg = args[linkIndex];
+  linkTarget = arg.includes("=") ? arg.slice(arg.indexOf("=") + 1) : args[linkIndex + 1];
+  if (!linkTarget) {
+    console.error("  --link needs a project directory: pack:local --link ../my-app");
+    process.exit(1);
+  }
+  linkTarget = path.resolve(process.cwd(), linkTarget);
+}
+
+const SUPPORTED_PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"];
+const pmIndex = args.findIndex((a) => a === "--pm" || a.startsWith("--pm="));
+let forcedPackageManager = null;
+if (pmIndex !== -1) {
+  const arg = args[pmIndex];
+  forcedPackageManager = arg.includes("=") ? arg.slice(arg.indexOf("=") + 1) : args[pmIndex + 1];
+  if (!SUPPORTED_PACKAGE_MANAGERS.includes(forcedPackageManager)) {
+    console.error(`  --pm must be one of: ${SUPPORTED_PACKAGE_MANAGERS.join(", ")}`);
+    process.exit(1);
+  }
+}
 
 fs.rmSync(DEST, { recursive: true, force: true });
 fs.mkdirSync(DEST, { recursive: true });
@@ -46,14 +80,190 @@ for (const group of groups) {
 }
 
 console.log(`\n${packed.length} tarball(s) in ${DEST}`);
-console.log(`\nInstall in a test project with:`);
-console.log(`  npm install ${DEST}/*.tgz`);
-console.log(
-  `\nScaffold with the packed CLI (local templates, no GitHub tag needed):`,
-);
-const cliTgz = fs.readdirSync(DEST).find((f) => f.startsWith("expressots-cli-"));
-if (cliTgz) {
+
+if (linkTarget) {
+  linkProject(linkTarget);
+} else {
+  console.log(`\nInstall in a test project with:`);
+  console.log(`  npm install ${DEST}/*.tgz`);
+  console.log(`\nOr point an existing project at this build:`);
+  console.log(`  pnpm pack:local --link ../my-test-app`);
   console.log(
-    `  EXPRESSOTS_TEMPLATE_REF=main npx --yes ${path.join(DEST, cliTgz)} new my-test-app`,
+    `\nScaffold with the packed CLI (local templates, no GitHub tag needed):`,
   );
+  const cliTgz = fs.readdirSync(DEST).find((f) => f.startsWith("expressots-cli-"));
+  if (cliTgz) {
+    console.log(
+      `  EXPRESSOTS_TEMPLATE_REF=main npx --yes ${path.join(DEST, cliTgz)} new my-test-app`,
+    );
+  }
+}
+
+/**
+ * Map @expressots/* package name -> tarball path, with a content hash in the
+ * filename.
+ *
+ * The hash is not cosmetic. Package managers cache `file:` specifiers by
+ * path, so reinstalling after a rebuild silently reuses the previous tarball
+ * and you test stale code — which looks exactly like "the fix doesn't work".
+ * A content-addressed name makes a changed build a different specifier, and
+ * an unchanged one still hit the cache.
+ */
+function buildTarballMap() {
+  const map = new Map();
+
+  for (const file of fs.readdirSync(DEST)) {
+    if (!file.endsWith(".tgz") || file.includes("-linked-")) continue;
+
+    const source = path.join(DEST, file);
+    const hash = crypto
+      .createHash("sha256")
+      .update(fs.readFileSync(source))
+      .digest("hex")
+      .slice(0, 8);
+
+    // expressots-adapter-express-4.1.1.tgz -> @expressots/adapter-express
+    const withoutExt = file.slice(0, -".tgz".length);
+    const name = withoutExt.replace(/^expressots-/, "").replace(/-\d[\d.]*.*$/, "");
+    const packageName = name === "expressots" ? "expressots" : `@expressots/${name}`;
+
+    const linkedName = `${withoutExt}-linked-${hash}.tgz`;
+    const linkedPath = path.join(DEST, linkedName);
+    if (!fs.existsSync(linkedPath)) {
+      fs.copyFileSync(source, linkedPath);
+    }
+
+    map.set(packageName, `file:${linkedPath}`);
+  }
+
+  return map;
+}
+
+function detectPackageManager(dir, pkg) {
+  if (forcedPackageManager) return forcedPackageManager;
+
+  // A `packageManager` field is authoritative when present (corepack).
+  const declared = pkg?.packageManager;
+  if (typeof declared === "string") {
+    const name = declared.split("@")[0];
+    if (SUPPORTED_PACKAGE_MANAGERS.includes(name)) return name;
+  }
+
+  if (fs.existsSync(path.join(dir, "bun.lock")) || fs.existsSync(path.join(dir, "bun.lockb")))
+    return "bun";
+  if (fs.existsSync(path.join(dir, "pnpm-lock.yaml"))) return "pnpm";
+  if (fs.existsSync(path.join(dir, "yarn.lock"))) return "yarn";
+  if (fs.existsSync(path.join(dir, "package-lock.json"))) return "npm";
+
+  // A freshly scaffolded project (EXPRESSOTS_SKIP_INSTALL) has no lockfile
+  // and records no package manager, so there is nothing to detect from.
+  // pnpm at least leaves a workspace file behind; otherwise fall back to npm
+  // and say so, since installing with the wrong one leaves a stray lockfile.
+  if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return "pnpm";
+
+  console.log(
+    `\n  No lockfile or packageManager field in the target — assuming npm.` +
+      `\n  Pass --pm bun|pnpm|yarn|npm to choose explicitly.`,
+  );
+  return "npm";
+}
+
+function linkProject(dir) {
+  const manifestPath = path.join(dir, "package.json");
+  if (!fs.existsSync(manifestPath)) {
+    console.error(`\n  --link: no package.json in ${dir}`);
+    process.exit(1);
+  }
+
+  const raw = fs.readFileSync(manifestPath, "utf8");
+  let pkg;
+  try {
+    pkg = JSON.parse(raw);
+  } catch (error) {
+    console.error(`\n  --link: ${manifestPath} is not valid JSON (${error.message})`);
+    process.exit(1);
+  }
+
+  const tarballs = buildTarballMap();
+  const packageManager = detectPackageManager(dir, pkg);
+  const linked = [];
+
+  // Rewrite only what the project already depends on. Adding packages it
+  // never asked for (studio, boost-ts) would change what is under test.
+  for (const section of ["dependencies", "devDependencies"]) {
+    for (const name of Object.keys(pkg[section] ?? {})) {
+      const tarball = tarballs.get(name);
+      if (tarball) {
+        pkg[section][name] = tarball;
+        linked.push(name);
+      }
+    }
+  }
+
+  if (linked.length === 0) {
+    console.error(`\n  --link: ${dir} has no @expressots/* dependencies to link`);
+    process.exit(1);
+  }
+
+  // Direct dependencies alone are not enough: @expressots/adapter-express
+  // depends on @expressots/core by version, so the published copy gets
+  // installed alongside the local one and the bundler picks the wrong file.
+  // Every package manager spells this differently.
+  const overrides = {};
+  for (const name of linked) {
+    overrides[name] = tarballs.get(name);
+  }
+  // Also pin framework packages the project does not list directly but that
+  // its dependencies will pull in transitively.
+  for (const [name, tarball] of tarballs) {
+    if (name.startsWith("@expressots/") && !overrides[name]) {
+      overrides[name] = tarball;
+    }
+  }
+
+  if (packageManager === "pnpm") {
+    // pnpm 10+ ignores the `pnpm` field in package.json; overrides live in
+    // pnpm-workspace.yaml.
+    writePnpmOverrides(dir, overrides);
+    delete pkg.overrides;
+    delete pkg.resolutions;
+  } else if (packageManager === "bun" || packageManager === "yarn") {
+    pkg.resolutions = { ...pkg.resolutions, ...overrides };
+  } else {
+    pkg.overrides = { ...pkg.overrides, ...overrides };
+  }
+
+  const indent = raw.match(/^[ \t]+/m)?.[0] ?? "  ";
+  fs.writeFileSync(manifestPath, `${JSON.stringify(pkg, null, indent)}\n`);
+
+  console.log(`\nLinked ${linked.length} package(s) into ${dir}:`);
+  for (const name of linked) console.log(`  ${name}`);
+  console.log(`\nInstalling with ${packageManager}...`);
+
+  try {
+    execSync(`${packageManager} install`, { cwd: dir, stdio: "inherit" });
+  } catch {
+    console.error(`\n  ${packageManager} install failed. Fix the errors above and rerun.`);
+    process.exit(1);
+  }
+
+  console.log(`\nDone. ${dir} now uses this build of the framework.`);
+  console.log(`Re-run pack:local --link after any change to the monorepo.`);
+}
+
+function writePnpmOverrides(dir, overrides) {
+  const workspacePath = path.join(dir, "pnpm-workspace.yaml");
+  const existing = fs.existsSync(workspacePath) ? fs.readFileSync(workspacePath, "utf8") : "";
+
+  // Replace a previous block rather than appending a second `overrides:` key,
+  // which would make the YAML invalid.
+  const withoutOverrides = existing.replace(/^overrides:\n(?:[ \t]+.*\n?)*/m, "");
+  const block = [
+    "overrides:",
+    ...Object.entries(overrides).map(([name, spec]) => `  "${name}": "${spec}"`),
+    "",
+  ].join("\n");
+
+  const separator = withoutOverrides.length === 0 || withoutOverrides.endsWith("\n") ? "" : "\n";
+  fs.writeFileSync(workspacePath, `${withoutOverrides}${separator}${block}`);
 }


### PR DESCRIPTION
:black_heart:

## PR Type
- [x] Build related changes
- [x] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What was changed?

Testing a framework change against a scaffolded app currently means hand-editing three dependency specs, knowing that npm spells `overrides` differently from bun's `resolutions` and that pnpm 10+ ignores the `pnpm` field in `package.json` entirely — and then discovering that re-linking after a rebuild silently reused a cached tarball. That cost real debugging time twice while working through the Cloudflare follow-ups.

```bash
pnpm pack:local --link ../my-app [--pm bun]
```

### What it does

- **Rewrites only the `@expressots/*` deps the app already has.** Adding packages it never asked for (studio, boost-ts) would change what is under test.
- **Pins the transitive ones too.** `@expressots/adapter-express` depends on `@expressots/core` *by version*, so without an override the published copy installs alongside the local one and the bundler resolves the wrong file — which presents as "the fix isn't working".
- **Writes overrides where each package manager actually reads them:** `pnpm-workspace.yaml` for pnpm, `resolutions` for bun/yarn, `overrides` for npm.
- **Content-hashes the tarball filenames.** Package managers cache `file:` specifiers by path, so an unchanged filename after a rebuild means you silently test stale code. This is the subtle one, and it is the failure that wasted the most time.
- **`--pm` overrides detection.** A freshly scaffolded app (`EXPRESSOTS_SKIP_INSTALL=1`) has no lockfile and records no `packageManager`, so there is nothing to infer from; without this it defaults to npm silently and leaves a stray `package-lock.json` in a bun project. When it does fall back, it now says so.

### Verification

Ran end to end against three freshly scaffolded Cloudflare Worker projects:

| Package manager | Linked | `build` | `test` (workerd) |
|---|---|---|---|
| npm | local core confirmed in `node_modules` | 537.36 KB gzip | 3/3 |
| pnpm | no stale registry copy in `.pnpm` | 539.39 KB gzip | — |
| bun (`--pm bun`) | `bun.lock`, no stray `package-lock.json` | 537.37 KB gzip | 3/3 |

And the cache-busting specifically: changed a string in `cloudflare.adapter.ts`, rebuilt, re-linked, and confirmed the new string was present in the app's `node_modules` — the case that previously required manually renaming tarballs.

`CONTRIBUTING_HOWTO.md` documents the new flow, with the manual tarball install kept as the fallback.

## Other information

Gates green: cli 553, adapter-express 411, core 2812, shared 68, boost-ts 3.