### PR TITLE
fix(core): sync framework version during release

### DIFF
--- a/packages/core/scripts/sync-version.js
+++ b/packages/core/scripts/sync-version.js
@@ -18,14 +18,19 @@ if (!version || typeof version !== "string") {
 const contents = `/**
  * Framework version string surfaced in startup banners and diagnostics.
  *
- * This file is auto-synced from the root \`package.json\` by
- * \`scripts/sync-version.js\` before each build. Do not edit by hand.
+ * Auto-synced from this package's \`package.json\` by
+ * \`packages/core/scripts/sync-version.js\`, which runs before each build and
+ * again during the release version bump. Do not edit by hand.
  */
 export const FRAMEWORK_VERSION = "${version}";
 `;
 
 const current = fs.existsSync(TARGET) ? fs.readFileSync(TARGET, "utf8") : "";
-if (current === contents) {
+// Git may check this generated source out with CRLF on Windows. Compare
+// normalized text so an otherwise current build does not rewrite it with LF
+// and leave a false-positive working-tree modification.
+const normalizedCurrent = current.replace(/\r\n?/g, "\n");
+if (normalizedCurrent === contents) {
   console.log(`[sync-version] framework-version.ts already at ${version}`);
 } else {
   fs.writeFileSync(TARGET, contents);

--- a/packages/core/src/framework-version.ts
+++ b/packages/core/src/framework-version.ts
@@ -1,7 +1,8 @@
 /**
  * Framework version string surfaced in startup banners and diagnostics.
  *
- * This file is auto-synced from the root `package.json` by
- * `scripts/sync-version.js` before each build. Do not edit by hand.
+ * Auto-synced from this package's `package.json` by
+ * `packages/core/scripts/sync-version.js`, which runs before each build and
+ * again during the release version bump. Do not edit by hand.
  */
-export const FRAMEWORK_VERSION = "4.0.0";
+export const FRAMEWORK_VERSION = "4.2.1";

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -398,6 +398,15 @@ async function versionStage(currentVersion) {
 
   const pinned = syncPinnedVersions(newVersion);
   if (pinned.length) record("version", `templates/examples pinned to v${newVersion}`, "pass", `${pinned.length} package.json file(s)`);
+
+  // Stage 2 built core while package.json still held the OLD version, so the
+  // generated framework-version.ts is a release behind by the time we get
+  // here. Re-sync after the bump so the banner reports the version we are
+  // actually publishing, and so the file lands in this release commit rather
+  // than surfacing as a stray diff in the next contributor's build.
+  execSync("pnpm --filter @expressots/core run sync-version", { cwd: ROOT, stdio: ["ignore", "inherit", "inherit"] });
+  record("version", `framework-version.ts synced to v${newVersion}`, "pass", "core banner version");
+
   sh("git add -A");
   sh(`git commit -m "chore(release): v${newVersion}"`, { stdio: ["ignore", "pipe", "pipe"] });
   record("version", `bumped to v${newVersion} and committed`, "pass", `changelogs updated`);


### PR DESCRIPTION
# Pull Request Guidelines

## Before submitting your PR, please verify the following:

- [x] The commit message follows the project guidelines.
- [ ] Tests for the changes have been added.
- [ ] Docs have been added / updated.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Test
- [ ] Other

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What was changed?

Closes #966. This is a clean re-land of #963 from the current `upstream/main`, limited to the three intended files.

`packages/core/src/framework-version.ts` was left at `4.0.0` while core had advanced to `4.2.1`. Builds generated the correct published artifact, but rewrote the tracked source and left contributors with a dirty worktree.

- Regenerates the tracked source at the current core package version.
- Runs `sync-version` immediately after `pnpm changeset version` and before the release commit, so the bumped value is committed with the release.
- Corrects the generated comment to point to core's package and script rather than the root package.
- Compares normalized line endings before writing, so a current CRLF checkout on Windows is not rewritten to LF and falsely reported as modified.

## Verification

- `pnpm --filter @expressots/core... build` passes.
- Core Jest suite: 328 suites / 2,812 tests pass.
- Core ESLint passes.
- Re-running `sync-version` against an equivalent CRLF source preserves the exact file hash.
- A forced dependency-aware core build leaves no tracked diff.

## Other information

No changeset is included: published artifacts are byte-identical because core's build already runs `sync-version` before compilation. The change corrects committed source and release bookkeeping.
